### PR TITLE
Fix pid delete and add Reasons and new signal

### DIFF
--- a/common.c
+++ b/common.c
@@ -3344,7 +3344,7 @@ ifaddrconf(cmd, ifname, addr, plen, pltime, vltime)
 	}
 #endif
 
-	d_printf(LOG_DEBUG, FNAME, "%s an address %s/%d on %s", cmdstr,
+	d_printf(LOG_INFO, FNAME, "%s an address %s/%d on %s", cmdstr,
 	    addr2str((struct sockaddr *)addr), plen, ifname);
 
 	close(s);

--- a/config.h
+++ b/config.h
@@ -162,7 +162,7 @@ struct dhcp6_serverinfo {
 
 /* client status code */
 enum {DHCP6S_INIT, DHCP6S_SOLICIT, DHCP6S_INFOREQ, DHCP6S_REQUEST,
-      DHCP6S_RENEW, DHCP6S_REBIND, DHCP6S_RELEASE, DHCP6S_IDLE};
+      DHCP6S_RENEW, DHCP6S_REBIND, DHCP6S_RELEASE, DHCP6S_IDLE, DHCP6S_EXIT};
 
 struct prefix_ifconf {
 	TAILQ_ENTRY(prefix_ifconf) link;

--- a/dhcp6c.c
+++ b/dhcp6c.c
@@ -82,9 +82,12 @@
 
 static int debug = 0;
 static int exit_ok = 0;
+
 static sig_atomic_t sig_flags = 0;
 #define SIGF_TERM 0x1
 #define SIGF_HUP 0x2
+#define SIGF_QUIT 0x4
+
 
 const dhcp6_mode_t dhcp6_mode = DHCP6_MODE_CLIENT;
 
@@ -109,6 +112,7 @@ static int ctldigestlen;
 static int infreq_mode = 0;
 
 int opt_norelease;
+static char *script_p;
 
 static inline int get_val32 __P((char **, int *, u_int32_t *));
 static inline int get_ifname __P((char **, int *, char *, int));
@@ -390,6 +394,11 @@ client6_init()
 		    strerror(errno));
 		exit(1);
 	}
+	if (signal(SIGUSR1, client6_signal) == SIG_ERR) {
+		d_printf(LOG_WARNING, FNAME, "failed to set signal: %s",
+		    strerror(errno));
+		exit(1);
+	}
 }
 
 int
@@ -454,6 +463,9 @@ free_resources(freeifp)
 {
 	struct dhcp6_if *ifp;
 
+	
+	script_p = NULL;
+	
 	for (ifp = dhcp6_if; ifp; ifp = ifp->next) {
 		struct dhcp6_event *ev, *ev_next;
 
@@ -461,6 +473,11 @@ free_resources(freeifp)
 			continue;
 
 		/* release all IAs as well as send RELEASE message(s) */
+		if(script_p == NULL) {
+		    script_p = ifp->scriptpath;
+		    
+		}
+		
 		release_all_ia(ifp);
 
 		/*
@@ -498,22 +515,37 @@ check_exit()
 	/* We have no existing event.  Do exit. */
 	d_printf(LOG_INFO, FNAME, "exiting");
 
+	if (strlen(script_p) != 0) {
+		 
+	       /* We are going to fire the script with and exit value */
+	        d_printf(LOG_DEBUG, FNAME, "shutdown executes %s", script_p);
+		client6_script(script_p, DHCP6S_EXIT, NULL);
+	} 
+	unlink(pid_file);
 	exit(0);
 }
 
 static void
 process_signals()
 {
+     
+	 
 	if ((sig_flags & SIGF_TERM)) {
 		exit_ok = 1;
 		free_resources(NULL);
-		unlink(pid_file);
 		check_exit();
 	}
 	if ((sig_flags & SIGF_HUP)) {
 		d_printf(LOG_INFO, FNAME, "restarting");
 		free_resources(NULL);
 		client6_startall(1);
+	}
+	if ((sig_flags & SIGF_QUIT)) {
+		d_printf(LOG_DEBUG, FNAME, "Forcing Exit");
+		exit_ok = 1;
+		opt_norelease = 1;
+		free_resources(NULL);
+		check_exit();
 	}
 
 	sig_flags = 0;
@@ -1161,6 +1193,9 @@ client6_signal(sig)
 	case SIGHUP:
 		sig_flags |= SIGF_HUP;
 		break;
+	case SIGUSR1:
+		sig_flags |= SIGF_QUIT;
+		break;
 	}
 }
 
@@ -1751,23 +1786,23 @@ client6_recvreply(ifp, dh6, len, optinfo)
 
 	switch (state) {
 	case DHCP6S_INFOREQ:
-		d_printf(LOG_INFO, FNAME, "dhcp6c Received INFOREQ");
-		break;  
-	case DHCP6S_REQUEST:
-		d_printf(LOG_INFO, FNAME, "dhcp6c Received REQUEST");
-		break;
-	case DHCP6S_RENEW:
-		d_printf(LOG_INFO, FNAME, "dhcp6c Received INFO");
-		break;
-	case DHCP6S_REBIND:
-		d_printf(LOG_INFO, FNAME, "dhcp6c Received REBIND");
-		break;
-	case DHCP6S_RELEASE:
-		d_printf(LOG_INFO, FNAME, "dhcp6c Received RELEASE");
-		break;
-	case DHCP6S_SOLICIT:
-		d_printf(LOG_INFO, FNAME, "dhcp6c Received SOLICIT");
-		break;          
+		d_printf(LOG_INFO, FNAME, "Received Info");
+ 		break;  
+ 	case DHCP6S_REQUEST:
+		d_printf(LOG_INFO, FNAME, "Received Reply");
+ 		break;
+ 	case DHCP6S_RENEW:
+		d_printf(LOG_INFO, FNAME, "Received Renew");
+ 		break;
+ 	case DHCP6S_REBIND:
+		d_printf(LOG_INFO, FNAME, "Received Rebind");
+ 		break;
+ 	case DHCP6S_RELEASE:
+		d_printf(LOG_INFO, FNAME, "Received Release");
+ 		break;
+ 	case DHCP6S_SOLICIT:
+		d_printf(LOG_INFO, FNAME, "Received Advert");
+ 		break;             
 	}
 
 	/* A Reply message must contain a Server ID option */

--- a/dhcp6c_script.c
+++ b/dhcp6c_script.c
@@ -71,6 +71,7 @@ static char nispserver_str[] = "new_nisp_servers";
 static char nispname_str[] = "new_nisp_name";
 static char bcmcsserver_str[] = "new_bcmcs_servers";
 static char bcmcsname_str[] = "new_bcmcs_name";
+static char reason[32];
 
 int
 client6_script(scriptpath, state, optinfo)
@@ -78,19 +79,43 @@ client6_script(scriptpath, state, optinfo)
 	int state;
 	struct dhcp6_optinfo *optinfo;
 {
-	int i, dnsservers, ntpservers, dnsnamelen, envc, elen, ret = 0;
+	int i,z, dnsservers, ntpservers, dnsnamelen, envc, elen, ret = 0;
 	int sipservers, sipnamelen;
 	int nisservers, nisnamelen;
 	int nispservers, nispnamelen;
 	int bcmcsservers, bcmcsnamelen;
 	char **envp, *s;
-	char reason[] = "REASON=NBI";
 	struct dhcp6_listval *v;
 	pid_t pid, wpid;
-
+	
+	switch(state) {
+	  case DHCP6S_INFOREQ:
+	    sprintf(reason,"REASON=INFO");
+	    break;
+	  case DHCP6S_REQUEST:
+	    sprintf(reason,"REASON=REPLY");
+	    break;
+	 case DHCP6S_RENEW:
+	    sprintf(reason,"REASON=RENEW");
+	    break;
+	case DHCP6S_REBIND:
+	    sprintf(reason,"REASON=REBIND");
+	    break;
+	case DHCP6S_RELEASE:
+	    sprintf(reason,"REASON=RELEASE");
+	    break;
+	case DHCP6S_EXIT:
+	    sprintf(reason,"REASON=EXIT");
+	    break;  
+	default:
+	    sprintf(reason,"REASON=OTHER");
+	}
+	
 	/* if a script is not specified, do nothing */
 	if (scriptpath == NULL || strlen(scriptpath) == 0)
 		return -1;
+
+	
 
 	/* initialize counters */
 	dnsservers = 0;
@@ -106,54 +131,56 @@ client6_script(scriptpath, state, optinfo)
 	bcmcsnamelen = 0;
 	envc = 2;     /* we at least include the reason and the terminator */
 
-	/* count the number of variables */
-	for (v = TAILQ_FIRST(&optinfo->dns_list); v; v = TAILQ_NEXT(v, link))
-		dnsservers++;
-	envc += dnsservers ? 1 : 0;
-	for (v = TAILQ_FIRST(&optinfo->dnsname_list); v;
-	    v = TAILQ_NEXT(v, link)) {
-		dnsnamelen += v->val_vbuf.dv_len;
-	}
-	envc += dnsnamelen ? 1 : 0;
-	for (v = TAILQ_FIRST(&optinfo->ntp_list); v; v = TAILQ_NEXT(v, link))
-		ntpservers++;
-	envc += ntpservers ? 1 : 0;
-	for (v = TAILQ_FIRST(&optinfo->sip_list); v; v = TAILQ_NEXT(v, link))
-		sipservers++;
-	envc += sipservers ? 1 : 0;
-	for (v = TAILQ_FIRST(&optinfo->sipname_list); v;
-	    v = TAILQ_NEXT(v, link)) {
-		sipnamelen += v->val_vbuf.dv_len;
-	}
-	envc += sipnamelen ? 1 : 0;
+	/* count the number of variables */  
+	if(state != DHCP6S_EXIT)
+	{
+		for (v = TAILQ_FIRST(&optinfo->dns_list); v; v = TAILQ_NEXT(v, link))
+			dnsservers++;
+		envc += dnsservers ? 1 : 0;
+		for (v = TAILQ_FIRST(&optinfo->dnsname_list); v;
+		    v = TAILQ_NEXT(v, link)) {
+			dnsnamelen += v->val_vbuf.dv_len;
+		}
+		envc += dnsnamelen ? 1 : 0;
+		for (v = TAILQ_FIRST(&optinfo->ntp_list); v; v = TAILQ_NEXT(v, link))
+			ntpservers++;
+		envc += ntpservers ? 1 : 0;
+		for (v = TAILQ_FIRST(&optinfo->sip_list); v; v = TAILQ_NEXT(v, link))
+			sipservers++;
+		envc += sipservers ? 1 : 0;
+		for (v = TAILQ_FIRST(&optinfo->sipname_list); v;
+		    v = TAILQ_NEXT(v, link)) {
+			sipnamelen += v->val_vbuf.dv_len;
+		}
+		envc += sipnamelen ? 1 : 0;
 
-	for (v = TAILQ_FIRST(&optinfo->nis_list); v; v = TAILQ_NEXT(v, link))
-		nisservers++;
-	envc += nisservers ? 1 : 0;
-	for (v = TAILQ_FIRST(&optinfo->nisname_list); v;
-	    v = TAILQ_NEXT(v, link)) {
-		nisnamelen += v->val_vbuf.dv_len;
-	}
-	envc += nisnamelen ? 1 : 0;
+		for (v = TAILQ_FIRST(&optinfo->nis_list); v; v = TAILQ_NEXT(v, link))
+			nisservers++;
+		envc += nisservers ? 1 : 0;
+		for (v = TAILQ_FIRST(&optinfo->nisname_list); v;
+		    v = TAILQ_NEXT(v, link)) {
+			nisnamelen += v->val_vbuf.dv_len;
+		}
+		envc += nisnamelen ? 1 : 0;
 
-	for (v = TAILQ_FIRST(&optinfo->nisp_list); v; v = TAILQ_NEXT(v, link))
-		nispservers++;
-	envc += nispservers ? 1 : 0;
-	for (v = TAILQ_FIRST(&optinfo->nispname_list); v;
-	    v = TAILQ_NEXT(v, link)) {
-		nispnamelen += v->val_vbuf.dv_len;
-	}
-	envc += nispnamelen ? 1 : 0;
+		for (v = TAILQ_FIRST(&optinfo->nisp_list); v; v = TAILQ_NEXT(v, link))
+			nispservers++;
+		envc += nispservers ? 1 : 0;
+		for (v = TAILQ_FIRST(&optinfo->nispname_list); v;
+		    v = TAILQ_NEXT(v, link)) {
+			nispnamelen += v->val_vbuf.dv_len;
+		}
+		envc += nispnamelen ? 1 : 0;
 
-	for (v = TAILQ_FIRST(&optinfo->bcmcs_list); v; v = TAILQ_NEXT(v, link))
-		bcmcsservers++;
-	envc += bcmcsservers ? 1 : 0;
-	for (v = TAILQ_FIRST(&optinfo->bcmcsname_list); v;
-	    v = TAILQ_NEXT(v, link)) {
-		bcmcsnamelen += v->val_vbuf.dv_len;
+		for (v = TAILQ_FIRST(&optinfo->bcmcs_list); v; v = TAILQ_NEXT(v, link))
+			bcmcsservers++;
+		envc += bcmcsservers ? 1 : 0;
+		for (v = TAILQ_FIRST(&optinfo->bcmcsname_list); v;
+		    v = TAILQ_NEXT(v, link)) {
+			bcmcsnamelen += v->val_vbuf.dv_len;
+		}
+		envc += bcmcsnamelen ? 1 : 0;
 	}
-	envc += bcmcsnamelen ? 1 : 0;
-
 	/* allocate an environments array */
 	if ((envp = malloc(sizeof (char *) * envc)) == NULL) {
 		d_printf(LOG_NOTICE, FNAME,
@@ -173,210 +200,214 @@ client6_script(scriptpath, state, optinfo)
 		ret = -1;
 		goto clean;
 	}
+
 	/* "var=addr1 addr2 ... addrN" + null char for termination */
-	if (dnsservers) {
-		elen = sizeof (dnsserver_str) +
-		    (INET6_ADDRSTRLEN + 1) * dnsservers + 1;
-		if ((s = envp[i++] = malloc(elen)) == NULL) {
-			d_printf(LOG_NOTICE, FNAME,
-			    "failed to allocate strings for DNS servers");
-			ret = -1;
-			goto clean;
-		}
-		memset(s, 0, elen);
-		snprintf(s, elen, "%s=", dnsserver_str);
-		for (v = TAILQ_FIRST(&optinfo->dns_list); v;
-		    v = TAILQ_NEXT(v, link)) {
-			char *addr;
+	if(state != DHCP6S_EXIT)
+	{
+		if (dnsservers) {
+			elen = sizeof (dnsserver_str) +
+			    (INET6_ADDRSTRLEN + 1) * dnsservers + 1;
+			if ((s = envp[i++] = malloc(elen)) == NULL) {
+				d_printf(LOG_NOTICE, FNAME,
+				    "failed to allocate strings for DNS servers");
+				ret = -1;
+				goto clean;
+			}
+			memset(s, 0, elen);
+			snprintf(s, elen, "%s=", dnsserver_str);
+			for (v = TAILQ_FIRST(&optinfo->dns_list); v;
+			    v = TAILQ_NEXT(v, link)) {
+				char *addr;
 
-			addr = in6addr2str(&v->val_addr6, 0);
-			strlcat(s, addr, elen);
-			strlcat(s, " ", elen);
+				addr = in6addr2str(&v->val_addr6, 0);
+				strlcat(s, addr, elen);
+				strlcat(s, " ", elen);
+			}
 		}
-	}
-	if (ntpservers) {
-		elen = sizeof (ntpserver_str) +
-		    (INET6_ADDRSTRLEN + 1) * ntpservers + 1;
-		if ((s = envp[i++] = malloc(elen)) == NULL) {
-			d_printf(LOG_NOTICE, FNAME,
-			    "failed to allocate strings for NTP servers");
-			ret = -1;
-			goto clean;
-		}
-		memset(s, 0, elen);
-		snprintf(s, elen, "%s=", ntpserver_str);
-		for (v = TAILQ_FIRST(&optinfo->ntp_list); v;
-		    v = TAILQ_NEXT(v, link)) {
-			char *addr;
+		if (ntpservers) {
+			elen = sizeof (ntpserver_str) +
+			    (INET6_ADDRSTRLEN + 1) * ntpservers + 1;
+			if ((s = envp[i++] = malloc(elen)) == NULL) {
+				d_printf(LOG_NOTICE, FNAME,
+				    "failed to allocate strings for NTP servers");
+				ret = -1;
+				goto clean;
+			}
+			memset(s, 0, elen);
+			snprintf(s, elen, "%s=", ntpserver_str);
+			for (v = TAILQ_FIRST(&optinfo->ntp_list); v;
+			    v = TAILQ_NEXT(v, link)) {
+				char *addr;
 
-			addr = in6addr2str(&v->val_addr6, 0);
-			strlcat(s, addr, elen);
-			strlcat(s, " ", elen);
+				addr = in6addr2str(&v->val_addr6, 0);
+				strlcat(s, addr, elen);
+				strlcat(s, " ", elen);
+			}
 		}
-	}
 
-	if (dnsnamelen) {
-		elen = sizeof (dnsname_str) + dnsnamelen + 1;
-		if ((s = envp[i++] = malloc(elen)) == NULL) {
-			d_printf(LOG_NOTICE, FNAME,
-			    "failed to allocate strings for DNS name");
-			ret = -1;
-			goto clean;
+		if (dnsnamelen) {
+			elen = sizeof (dnsname_str) + dnsnamelen + 1;
+			if ((s = envp[i++] = malloc(elen)) == NULL) {
+				d_printf(LOG_NOTICE, FNAME,
+				    "failed to allocate strings for DNS name");
+				ret = -1;
+				goto clean;
+			}
+			memset(s, 0, elen);
+			snprintf(s, elen, "%s=", dnsname_str);
+			for (v = TAILQ_FIRST(&optinfo->dnsname_list); v;
+			    v = TAILQ_NEXT(v, link)) {
+				strlcat(s, v->val_vbuf.dv_buf, elen);
+				strlcat(s, " ", elen);
+			}
 		}
-		memset(s, 0, elen);
-		snprintf(s, elen, "%s=", dnsname_str);
-		for (v = TAILQ_FIRST(&optinfo->dnsname_list); v;
-		    v = TAILQ_NEXT(v, link)) {
-			strlcat(s, v->val_vbuf.dv_buf, elen);
-			strlcat(s, " ", elen);
-		}
-	}
 
-	if (sipservers) {
-		elen = sizeof (sipserver_str) +
-		    (INET6_ADDRSTRLEN + 1) * sipservers + 1;
-		if ((s = envp[i++] = malloc(elen)) == NULL) {
-			d_printf(LOG_NOTICE, FNAME,
-			    "failed to allocate strings for SIP servers");
-			ret = -1;
-			goto clean;
-		}
-		memset(s, 0, elen);
-		snprintf(s, elen, "%s=", sipserver_str);
-		for (v = TAILQ_FIRST(&optinfo->sip_list); v;
-		    v = TAILQ_NEXT(v, link)) {
-			char *addr;
+		if (sipservers) {
+			elen = sizeof (sipserver_str) +
+			    (INET6_ADDRSTRLEN + 1) * sipservers + 1;
+			if ((s = envp[i++] = malloc(elen)) == NULL) {
+				d_printf(LOG_NOTICE, FNAME,
+				    "failed to allocate strings for SIP servers");
+				ret = -1;
+				goto clean;
+			}
+			memset(s, 0, elen);
+			snprintf(s, elen, "%s=", sipserver_str);
+			for (v = TAILQ_FIRST(&optinfo->sip_list); v;
+			    v = TAILQ_NEXT(v, link)) {
+				char *addr;
 
-			addr = in6addr2str(&v->val_addr6, 0);
-			strlcat(s, addr, elen);
-			strlcat(s, " ", elen);
+				addr = in6addr2str(&v->val_addr6, 0);
+				strlcat(s, addr, elen);
+				strlcat(s, " ", elen);
+			}
 		}
-	}
-	if (sipnamelen) {
-		elen = sizeof (sipname_str) + sipnamelen + 1;
-		if ((s = envp[i++] = malloc(elen)) == NULL) {
-			d_printf(LOG_NOTICE, FNAME,
-			    "failed to allocate strings for SIP domain name");
-			ret = -1;
-			goto clean;
+		if (sipnamelen) {
+			elen = sizeof (sipname_str) + sipnamelen + 1;
+			if ((s = envp[i++] = malloc(elen)) == NULL) {
+				d_printf(LOG_NOTICE, FNAME,
+				    "failed to allocate strings for SIP domain name");
+				ret = -1;
+				goto clean;
+			}
+			memset(s, 0, elen);
+			snprintf(s, elen, "%s=", sipname_str);
+			for (v = TAILQ_FIRST(&optinfo->sipname_list); v;
+			    v = TAILQ_NEXT(v, link)) {
+				strlcat(s, v->val_vbuf.dv_buf, elen);
+				strlcat(s, " ", elen);
+			}
 		}
-		memset(s, 0, elen);
-		snprintf(s, elen, "%s=", sipname_str);
-		for (v = TAILQ_FIRST(&optinfo->sipname_list); v;
-		    v = TAILQ_NEXT(v, link)) {
-			strlcat(s, v->val_vbuf.dv_buf, elen);
-			strlcat(s, " ", elen);
-		}
-	}
 
-	if (nisservers) {
-		elen = sizeof (nisserver_str) +
-		    (INET6_ADDRSTRLEN + 1) * nisservers + 1;
-		if ((s = envp[i++] = malloc(elen)) == NULL) {
-			d_printf(LOG_NOTICE, FNAME,
-			    "failed to allocate strings for NIS servers");
-			ret = -1;
-			goto clean;
-		}
-		memset(s, 0, elen);
-		snprintf(s, elen, "%s=", nisserver_str);
-		for (v = TAILQ_FIRST(&optinfo->nis_list); v;
-		    v = TAILQ_NEXT(v, link)) {
-			char *addr;
+		if (nisservers) {
+			elen = sizeof (nisserver_str) +
+			    (INET6_ADDRSTRLEN + 1) * nisservers + 1;
+			if ((s = envp[i++] = malloc(elen)) == NULL) {
+				d_printf(LOG_NOTICE, FNAME,
+				    "failed to allocate strings for NIS servers");
+				ret = -1;
+				goto clean;
+			}
+			memset(s, 0, elen);
+			snprintf(s, elen, "%s=", nisserver_str);
+			for (v = TAILQ_FIRST(&optinfo->nis_list); v;
+			    v = TAILQ_NEXT(v, link)) {
+				char *addr;
 
-			addr = in6addr2str(&v->val_addr6, 0);
-			strlcat(s, addr, elen);
-			strlcat(s, " ", elen);
+				addr = in6addr2str(&v->val_addr6, 0);
+				strlcat(s, addr, elen);
+				strlcat(s, " ", elen);
+			}
 		}
-	}
-	if (nisnamelen) {
-		elen = sizeof (nisname_str) + nisnamelen + 1;
-		if ((s = envp[i++] = malloc(elen)) == NULL) {
-			d_printf(LOG_NOTICE, FNAME,
-			    "failed to allocate strings for NIS domain name");
-			ret = -1;
-			goto clean;
+		if (nisnamelen) {
+			elen = sizeof (nisname_str) + nisnamelen + 1;
+			if ((s = envp[i++] = malloc(elen)) == NULL) {
+				d_printf(LOG_NOTICE, FNAME,
+				    "failed to allocate strings for NIS domain name");
+				ret = -1;
+				goto clean;
+			}
+			memset(s, 0, elen);
+			snprintf(s, elen, "%s=", nisname_str);
+			for (v = TAILQ_FIRST(&optinfo->nisname_list); v;
+			    v = TAILQ_NEXT(v, link)) {
+				strlcat(s, v->val_vbuf.dv_buf, elen);
+				strlcat(s, " ", elen);
+			}
 		}
-		memset(s, 0, elen);
-		snprintf(s, elen, "%s=", nisname_str);
-		for (v = TAILQ_FIRST(&optinfo->nisname_list); v;
-		    v = TAILQ_NEXT(v, link)) {
-			strlcat(s, v->val_vbuf.dv_buf, elen);
-			strlcat(s, " ", elen);
-		}
-	}
 
-	if (nispservers) {
-		elen = sizeof (nispserver_str) +
-		    (INET6_ADDRSTRLEN + 1) * nispservers + 1;
-		if ((s = envp[i++] = malloc(elen)) == NULL) {
-			d_printf(LOG_NOTICE, FNAME,
-			    "failed to allocate strings for NIS+ servers");
-			ret = -1;
-			goto clean;
-		}
-		memset(s, 0, elen);
-		snprintf(s, elen, "%s=", nispserver_str);
-		for (v = TAILQ_FIRST(&optinfo->nisp_list); v;
-		    v = TAILQ_NEXT(v, link)) {
-			char *addr;
+		if (nispservers) {
+			elen = sizeof (nispserver_str) +
+			    (INET6_ADDRSTRLEN + 1) * nispservers + 1;
+			if ((s = envp[i++] = malloc(elen)) == NULL) {
+				d_printf(LOG_NOTICE, FNAME,
+				    "failed to allocate strings for NIS+ servers");
+				ret = -1;
+				goto clean;
+			}
+			memset(s, 0, elen);
+			snprintf(s, elen, "%s=", nispserver_str);
+			for (v = TAILQ_FIRST(&optinfo->nisp_list); v;
+			    v = TAILQ_NEXT(v, link)) {
+				char *addr;
 
-			addr = in6addr2str(&v->val_addr6, 0);
-			strlcat(s, addr, elen);
-			strlcat(s, " ", elen);
+				addr = in6addr2str(&v->val_addr6, 0);
+				strlcat(s, addr, elen);
+				strlcat(s, " ", elen);
+			}
 		}
-	}
-	if (nispnamelen) {
-		elen = sizeof (nispname_str) + nispnamelen + 1;
-		if ((s = envp[i++] = malloc(elen)) == NULL) {
-			d_printf(LOG_NOTICE, FNAME,
-			    "failed to allocate strings for NIS+ domain name");
-			ret = -1;
-			goto clean;
+		if (nispnamelen) {
+			elen = sizeof (nispname_str) + nispnamelen + 1;
+			if ((s = envp[i++] = malloc(elen)) == NULL) {
+				d_printf(LOG_NOTICE, FNAME,
+				    "failed to allocate strings for NIS+ domain name");
+				ret = -1;
+				goto clean;
+			}
+			memset(s, 0, elen);
+			snprintf(s, elen, "%s=", nispname_str);
+			for (v = TAILQ_FIRST(&optinfo->nispname_list); v;
+			    v = TAILQ_NEXT(v, link)) {
+				strlcat(s, v->val_vbuf.dv_buf, elen);
+				strlcat(s, " ", elen);
+			}
 		}
-		memset(s, 0, elen);
-		snprintf(s, elen, "%s=", nispname_str);
-		for (v = TAILQ_FIRST(&optinfo->nispname_list); v;
-		    v = TAILQ_NEXT(v, link)) {
-			strlcat(s, v->val_vbuf.dv_buf, elen);
-			strlcat(s, " ", elen);
-		}
-	}
 
-	if (bcmcsservers) {
-		elen = sizeof (bcmcsserver_str) +
-		    (INET6_ADDRSTRLEN + 1) * bcmcsservers + 1;
-		if ((s = envp[i++] = malloc(elen)) == NULL) {
-			d_printf(LOG_NOTICE, FNAME,
-			    "failed to allocate strings for BCMC servers");
-			ret = -1;
-			goto clean;
-		}
-		memset(s, 0, elen);
-		snprintf(s, elen, "%s=", bcmcsserver_str);
-		for (v = TAILQ_FIRST(&optinfo->bcmcs_list); v;
-		    v = TAILQ_NEXT(v, link)) {
-			char *addr;
+		if (bcmcsservers) {
+			elen = sizeof (bcmcsserver_str) +
+			    (INET6_ADDRSTRLEN + 1) * bcmcsservers + 1;
+			if ((s = envp[i++] = malloc(elen)) == NULL) {
+				d_printf(LOG_NOTICE, FNAME,
+				    "failed to allocate strings for BCMC servers");
+				ret = -1;
+				goto clean;
+			}
+			memset(s, 0, elen);
+			snprintf(s, elen, "%s=", bcmcsserver_str);
+			for (v = TAILQ_FIRST(&optinfo->bcmcs_list); v;
+			    v = TAILQ_NEXT(v, link)) {
+				char *addr;
 
-			addr = in6addr2str(&v->val_addr6, 0);
-			strlcat(s, addr, elen);
-			strlcat(s, " ", elen);
+				addr = in6addr2str(&v->val_addr6, 0);
+				strlcat(s, addr, elen);
+				strlcat(s, " ", elen);
+			}
 		}
-	}
-	if (bcmcsnamelen) {
-		elen = sizeof (bcmcsname_str) + bcmcsnamelen + 1;
-		if ((s = envp[i++] = malloc(elen)) == NULL) {
-			d_printf(LOG_NOTICE, FNAME,
-			    "failed to allocate strings for BCMC domain name");
-			ret = -1;
-			goto clean;
-		}
-		memset(s, 0, elen);
-		snprintf(s, elen, "%s=", bcmcsname_str);
-		for (v = TAILQ_FIRST(&optinfo->bcmcsname_list); v;
-		    v = TAILQ_NEXT(v, link)) {
-			strlcat(s, v->val_vbuf.dv_buf, elen);
-			strlcat(s, " ", elen);
+		if (bcmcsnamelen) {
+			elen = sizeof (bcmcsname_str) + bcmcsnamelen + 1;
+			if ((s = envp[i++] = malloc(elen)) == NULL) {
+				d_printf(LOG_NOTICE, FNAME,
+				    "failed to allocate strings for BCMC domain name");
+				ret = -1;
+				goto clean;
+			}
+			memset(s, 0, elen);
+			snprintf(s, elen, "%s=", bcmcsname_str);
+			for (v = TAILQ_FIRST(&optinfo->bcmcsname_list); v;
+			    v = TAILQ_NEXT(v, link)) {
+				strlcat(s, v->val_vbuf.dv_buf, elen);
+				strlcat(s, " ", elen);
+			}
 		}
 	}
 


### PR DESCRIPTION
Corrected an issue with client deletng its pid while still sending signals; on SIGTERM if the interface went offline,  dhcp6c would sit and send release signals, even though had deleted the pid, thus any check to see if the process was still running by pid would return false even although the client was in fact still running.

Added new reasons to env var 'REASON=' when launching script. Previously dhcp6c only set REASON=NBI, now it will set one of the following on calling the script: INFO, REPLY, RENEW, RELEASE, REBIND, EXIT and OTHER. 

EXIT only gets set as the program exits, no other env vars will get passed when EXIT is set, OTHER is a catchall and should not happen.

Added new signal to exit with no-release without dependency on command line flag. This allows dynamic no-release exit without the use of the -n flag.