### PR TITLE
Moved  pid unlink. Added Reasons for script. Added signals

### DIFF
--- a/common.c
+++ b/common.c
@@ -3344,7 +3344,7 @@ ifaddrconf(cmd, ifname, addr, plen, pltime, vltime)
 	}
 #endif
 
-	d_printf(LOG_DEBUG, FNAME, "%s an address %s/%d on %s", cmdstr,
+	d_printf(LOG_INFO, FNAME, "%s an address %s/%d on %s", cmdstr,
 	    addr2str((struct sockaddr *)addr), plen, ifname);
 
 	close(s);

--- a/config.h
+++ b/config.h
@@ -162,7 +162,7 @@ struct dhcp6_serverinfo {
 
 /* client status code */
 enum {DHCP6S_INIT, DHCP6S_SOLICIT, DHCP6S_INFOREQ, DHCP6S_REQUEST,
-      DHCP6S_RENEW, DHCP6S_REBIND, DHCP6S_RELEASE, DHCP6S_IDLE};
+      DHCP6S_RENEW, DHCP6S_REBIND, DHCP6S_RELEASE, DHCP6S_IDLE, DHCP6S_EXIT};
 
 struct prefix_ifconf {
 	TAILQ_ENTRY(prefix_ifconf) link;

--- a/dhcp6c.c
+++ b/dhcp6c.c
@@ -1786,7 +1786,7 @@ client6_recvreply(ifp, dh6, len, optinfo)
 	}
 
 	switch (state) {
-		case DHCP6S_INFOREQ:
+	case DHCP6S_INFOREQ:
 		d_printf(LOG_INFO, FNAME, "Received Info");
 		break;  
 	case DHCP6S_REQUEST:

--- a/dhcp6c.c
+++ b/dhcp6c.c
@@ -85,6 +85,8 @@ static int exit_ok = 0;
 static sig_atomic_t sig_flags = 0;
 #define SIGF_TERM 0x1
 #define SIGF_HUP 0x2
+#define SIGF_QUITN 0x4
+#define SIGF_QUITR 0x8
 
 const dhcp6_mode_t dhcp6_mode = DHCP6_MODE_CLIENT;
 
@@ -109,6 +111,7 @@ static int ctldigestlen;
 static int infreq_mode = 0;
 
 int opt_norelease;
+static char *script_p;
 
 static inline int get_val32 __P((char **, int *, u_int32_t *));
 static inline int get_ifname __P((char **, int *, char *, int));
@@ -390,6 +393,16 @@ client6_init()
 		    strerror(errno));
 		exit(1);
 	}
+	if (signal(SIGUSR1, client6_signal) == SIG_ERR) {
+		d_printf(LOG_WARNING, FNAME, "failed to set signal: %s",
+		    strerror(errno));
+		exit(1);
+	}
+	if (signal(SIGUSR2, client6_signal) == SIG_ERR) {
+		d_printf(LOG_WARNING, FNAME, "failed to set signal: %s",
+		    strerror(errno));
+		exit(1);
+	}
 }
 
 int
@@ -494,10 +507,15 @@ check_exit()
 		if (!TAILQ_EMPTY(&ifp->event_list))
 			return;
 	}
-
 	/* We have no existing event.  Do exit. */
+	if (strlen(script_p) != 0) {
+		 
+	       /* We are going to fire the script with and exit value */
+	        d_printf(LOG_DEBUG, FNAME, "shutdown executes %s", script_p);
+		client6_script(script_p, DHCP6S_EXIT, NULL);
+	} 
 	d_printf(LOG_INFO, FNAME, "exiting");
-
+	unlink(pid_file);
 	exit(0);
 }
 
@@ -507,7 +525,6 @@ process_signals()
 	if ((sig_flags & SIGF_TERM)) {
 		exit_ok = 1;
 		free_resources(NULL);
-		unlink(pid_file);
 		check_exit();
 	}
 	if ((sig_flags & SIGF_HUP)) {
@@ -515,7 +532,20 @@ process_signals()
 		free_resources(NULL);
 		client6_startall(1);
 	}
-
+	if ((sig_flags & SIGF_QUITN)) {
+		d_printf(LOG_DEBUG, FNAME, "Forcing Exit - Set no-release");
+		exit_ok = 1;
+		opt_norelease = 1;
+		free_resources(NULL);
+		check_exit();
+	}
+	if ((sig_flags & SIGF_QUITR)) {
+		d_printf(LOG_DEBUG, FNAME, "Forcing Exit - Ignore no-release flag");
+		exit_ok = 1;
+		opt_norelease = 0;
+		free_resources(NULL);
+		check_exit();
+	}
 	sig_flags = 0;
 }
 
@@ -1161,6 +1191,12 @@ client6_signal(sig)
 	case SIGHUP:
 		sig_flags |= SIGF_HUP;
 		break;
+	case SIGUSR1:
+		sig_flags |= SIGF_QUITN;
+		break;
+	case SIGUSR2:
+		sig_flags |= SIGF_QUITR;
+		break;
 	}
 }
 
@@ -1751,23 +1787,23 @@ client6_recvreply(ifp, dh6, len, optinfo)
 
 	switch (state) {
 	case DHCP6S_INFOREQ:
-		d_printf(LOG_INFO, FNAME, "dhcp6c Received INFOREQ");
-		break;  
-	case DHCP6S_REQUEST:
-		d_printf(LOG_INFO, FNAME, "dhcp6c Received REQUEST");
-		break;
-	case DHCP6S_RENEW:
-		d_printf(LOG_INFO, FNAME, "dhcp6c Received INFO");
-		break;
-	case DHCP6S_REBIND:
-		d_printf(LOG_INFO, FNAME, "dhcp6c Received REBIND");
-		break;
-	case DHCP6S_RELEASE:
-		d_printf(LOG_INFO, FNAME, "dhcp6c Received RELEASE");
-		break;
-	case DHCP6S_SOLICIT:
-		d_printf(LOG_INFO, FNAME, "dhcp6c Received SOLICIT");
-		break;          
+		d_printf(LOG_INFO, FNAME, "Received Info");
+ 		break;  
+ 	case DHCP6S_REQUEST:
+		d_printf(LOG_INFO, FNAME, "Received Reply");
+ 		break;
+ 	case DHCP6S_RENEW:
+		d_printf(LOG_INFO, FNAME, "Received Renew");
+ 		break;
+ 	case DHCP6S_REBIND:
+		d_printf(LOG_INFO, FNAME, "Received Rebind");
+ 		break;
+ 	case DHCP6S_RELEASE:
+		d_printf(LOG_INFO, FNAME, "Received Release");
+ 		break;
+ 	case DHCP6S_SOLICIT:
+		d_printf(LOG_INFO, FNAME, "Received Advert");
+ 		break;
 	}
 
 	/* A Reply message must contain a Server ID option */

--- a/dhcp6c.c
+++ b/dhcp6c.c
@@ -1786,24 +1786,24 @@ client6_recvreply(ifp, dh6, len, optinfo)
 	}
 
 	switch (state) {
-	case DHCP6S_INFOREQ:
+		case DHCP6S_INFOREQ:
 		d_printf(LOG_INFO, FNAME, "Received Info");
- 		break;  
- 	case DHCP6S_REQUEST:
+		break;  
+	case DHCP6S_REQUEST:
 		d_printf(LOG_INFO, FNAME, "Received Reply");
- 		break;
- 	case DHCP6S_RENEW:
+		break;
+	case DHCP6S_RENEW:
 		d_printf(LOG_INFO, FNAME, "Received Renew");
- 		break;
- 	case DHCP6S_REBIND:
+		break;
+	case DHCP6S_REBIND:
 		d_printf(LOG_INFO, FNAME, "Received Rebind");
- 		break;
- 	case DHCP6S_RELEASE:
+		break;
+	case DHCP6S_RELEASE:
 		d_printf(LOG_INFO, FNAME, "Received Release");
- 		break;
- 	case DHCP6S_SOLICIT:
+		break;
+	case DHCP6S_SOLICIT:
 		d_printf(LOG_INFO, FNAME, "Received Advert");
- 		break;
+		break;
 	}
 
 	/* A Reply message must contain a Server ID option */


### PR DESCRIPTION
pid unlink was called before all processes were complete. This could
leave dhcp6c still runing sending and waiting for release but any check
for process by PID returned false, moved to just before exit(0);

Env var REASONS only returned NBI, now returns various reasons for
script call, these can be:
REASON=INFO
REASON=REPLY
REASON=RENEW
REASON=RELEASE
REASON=REBIND
REASON=EXIT
REASON=OTHER

EXIT will be signalled when the client exits.
OTHER is a catchall and should never happen.

Signals SIGUSR1 and SIGUSR2 are added. These are used to force an exit
ignoring the state of the no-release flag. SIGUSR1 forces a no-release
exit.
SGUSR2 forces a release exit.

Logging info changes to case and text; logging change to indicate PD or
IA in info mode rather than debug.