### PR TITLE
fix parallel build on FreeBSD

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -73,8 +73,10 @@ dhcp6relay: $(RELAYOBJS) $(LIBOBJS)
 dhcp6ctl: $(CTLOBJS)
 	$(CC) $(LDFLAGS) -o $@ $(CTLOBJS) $(LIBOBJS) $(LIBS)
 
-cfparse.c y.tab.h: cfparse.y
+y.tab.h: cfparse.y
 	@YACC@ -d cfparse.y
+
+cfparse.c: y.tab.h cfparse.y
 	mv y.tab.c cfparse.c
 
 cftoken.c: cftoken.l y.tab.h


### PR DESCRIPTION
I had problems building this port on my FreeBSD 11-STABLE system due to the fact that cftoken.c and cfparse.c targets seemed to execute in parallel, therefore "mv y.tab.c cfparse.c" was failing. After moving y.tab.h out as a separate target - they seem to run fine even without MAKE_JOBS_UNSAFE=yes