### PR TITLE
dhcp6s fails with shutdown(outbound, 0): Socket is not connected on FreeBSD 11

### DIFF
--- a/dhcp6s.c
+++ b/dhcp6s.c
@@ -524,7 +524,7 @@ server6_init()
 		    strerror(errno));
 		exit(1);
 	}
-#if !defined(__linux__) && !defined(__sun__)
+#if !defined(__linux__) && !defined(__sun__) && !defined(__FreeBSD__)
 	/* make the socket write-only */
 	if (shutdown(outsock, 0)) {
 		d_printf(LOG_ERR, FNAME, "shutdown(outbound, 0): %s",


### PR DESCRIPTION
FreeBSD 11 r285910 changed shutdown on UDP socket to return error.
This change disables the shutdown call in dhcp6s on FreeBSD.

Example of rtsold change in FreeBSD src (the shutdown call was removed)
https://svnweb.freebsd.org/base?view=revision&revision=286566