### PR TITLE
Add the ability to use RAW parameters in the config

### DIFF
--- a/cftoken.l
+++ b/cftoken.l
@@ -1,6 +1,5 @@
 /*	$KAME: cftoken.l,v 1.35 2005/01/12 06:06:11 suz Exp $	*/
 
-%option noinput
 %{
 /*
  * Copyright (C) 2002 WIDE Project.
@@ -54,9 +53,6 @@
 
 #define YY_NO_UNPUT 1
 
-extern char *configfilename;
-extern int lineno;
-
 char *configfilename;
 int lineno = 1;
 
@@ -69,28 +65,24 @@ static struct include_stack {
 	YY_BUFFER_STATE state;
 	int lineno;
 } incstack[MAX_INCLUDE_DEPTH];
-static int incstackp = 0;
+int incstackp = 0;
 
 
 static int yy_first_time = 1;
 static int yyerrorcount = 0;
-
+ 
 #ifndef NOCONFIG_DEBUG
-#ifndef YYDEBUG
 #define YYDEBUG 1
-#endif
-static int cfdebug = 1;
+
+int cfdebug = 1;
 #else
-static int cfdebug = 0;
+int cfdebug = 0;
 #endif
 
-extern int yyparse(void);
-extern int cf_post_config(void);
+extern int yyparse __P((void));
+extern int cf_post_config __P((void));
 
-static void cfdebug_print(const char *, const char *, int);
-void yyerror(const char *, ...);
-void yywarn(char *, ...);
-int cfswitch_buffer(char *);
+static void cfdebug_print __P((char *, char *, int));
 
 #define DP(str) if (cfdebug) cfdebug_print(str, yytext, yyleng)
 #define DECHO if (cfdebug) cfdebug_print(NULL, yytext, yyleng);
@@ -117,6 +109,9 @@ slash		\/
 bcl		\{
 ecl		\}
 
+/* XXX */
+hexdata 	{hexpair}(:{hexpair})*
+
 %s S_CNF
 %s S_IFACE
 %s S_PREF
@@ -128,6 +123,8 @@ ecl		\}
 %s S_SECRET
 %s S_ADDRPOOL
 %s S_INCL
+/* XXX */
+%s S_RAW
 
 %%
 %{
@@ -155,7 +152,7 @@ ecl		\}
 }
 
 	/* address pool configuration */
-<S_CNF>pool { DECHO; BEGIN S_ADDRPOOL; return (ADDRPOOL); }
+<S_CNF>pool { DECHO; BEGIN S_ADDRPOOL; return (ADDRPOOL); }  
 
 <S_ADDRPOOL>{string} {
 	DECHO;
@@ -213,10 +210,19 @@ ecl		\}
 <S_CNF>bcmcs-server-address { DECHO; return (BCMCS_SERVERS); }
 <S_CNF>bcmcs-server-domain-name { DECHO; return (BCMCS_NAME); }
 <S_CNF>refreshtime { DECHO; return (REFRESHTIME); }
+	/* XXX */
+<S_CNF>raw-option { DECHO; BEGIN S_RAW; return (RAW); }
+<S_RAW>{integer} { DECHO; yylval.str = strdup(yytext); return(NUMBER); }
+<S_RAW>{hexdata} {
+	DECHO;
+	yylval.str = strdup(yytext);
+	BEGIN S_CNF;
+	return (STRING);
+}
 
 	/* provided for a backward compatibility to WIDE-DHCPv6 before Oct 1 2006 */
 <S_CNF>nis-server-domain-name { DECHO; return (NIS_NAME); }
-<S_CNF>nisp-server-domain-name { DECHO; return (NISP_NAME); }
+<S_CNF>nisp-server-domain-name { DECHO; return (NISP_NAME); }	
 
 	/* generic options */
 <S_CNF>information-only { DECHO; return (INFO_ONLY); }
@@ -343,7 +349,9 @@ ecl		\}
 
 %%
 static void
-cfdebug_print(const char *w, const char *t, int l)
+cfdebug_print(w, t, l)
+	char *w, *t;
+	int l;
 {
 	if (w) {
 		d_printf(LOG_DEBUG, FNAME,
@@ -355,7 +363,7 @@ cfdebug_print(const char *w, const char *t, int l)
 }
 
 static void
-yyerror0(int level, const char *s, va_list ap)
+yyerror0(int level, char *s, va_list ap)
 {
 	char ebuf[BUFSIZ], *bp, *ep;
 
@@ -369,7 +377,7 @@ yyerror0(int level, const char *s, va_list ap)
 }
 
 void
-yyerror(const char *s, ...)
+yyerror(char *s, ...)
 {
 	va_list ap;
 #ifdef HAVE_STDARG_H
@@ -396,7 +404,8 @@ yywarn(char *s, ...)
 }
 
 int
-cfswitch_buffer(char *incl)
+cfswitch_buffer(incl)
+	char *incl;
 {
 	char *path = qstrdup(incl);
 	FILE *fp;
@@ -428,12 +437,10 @@ cfswitch_buffer(char *incl)
 }
 
 int
-cfparse(const char *conf)
+cfparse(conf)
+	char *conf;
 {
-
-	free(configfilename);
-	configfilename = strdup(conf);
-
+	configfilename = conf;
 	if ((yyin = fopen(configfilename, "r")) == NULL) {
 		d_printf(LOG_ERR, FNAME, "cfparse: fopen(%s): %s",
 			configfilename, strerror(errno));

--- a/common.c
+++ b/common.c
@@ -81,17 +81,17 @@
 #include <netdb.h>
 #include <ifaddrs.h>
 
-#include "dhcp6.h"
-#include "config.h"
-#include "common.h"
-#include "timer.h"
+#include <dhcp6.h>
+#include <config.h>
+#include <common.h>
+#include <timer.h>
 
 #ifdef __linux__
 /* from /usr/include/linux/ipv6.h */
 
 struct in6_ifreq {
 	struct in6_addr ifr6_addr;
-	uint32_t ifr6_prefixlen;
+	u_int32_t ifr6_prefixlen;
 	unsigned int ifr6_ifindex;
 };
 #endif
@@ -101,21 +101,121 @@ struct in6_ifreq {
 int foreground;
 int debug_thresh;
 
-static int dhcp6_count_list(struct dhcp6_list *);
-static int in6_matchflags(struct sockaddr *, char *, int);
-static ssize_t dnsencode(const char *, char *, size_t);
-static char *dnsdecode(u_char **, u_char *, char *, size_t);
-static int copyout_option(char *, char *, struct dhcp6_listval *);
-static int copyin_option(int, struct dhcp6opt *, struct dhcp6opt *,
-    struct dhcp6_list *);
-static int copy_option(uint16_t, uint16_t, void *, struct dhcp6opt **,
-    struct dhcp6opt *, int *);
-static ssize_t gethwid(char *, int, const char *, uint16_t *);
-static char *sprint_uint64(char *, int, uint64_t);
-static char *sprint_auth(struct dhcp6_optinfo *);
+static int dhcp6_count_list __P((struct dhcp6_list *));
+static int in6_matchflags __P((struct sockaddr *, char *, int));
+static ssize_t dnsencode __P((const char *, char *, size_t));
+static char *dnsdecode __P((u_char **, u_char *, char *, size_t));
+static int copyout_option __P((char *, char *, struct dhcp6_listval *));
+static int copyin_option __P((int, struct dhcp6opt *, struct dhcp6opt *,
+    struct dhcp6_list *));
+static int copy_option __P((u_int16_t, u_int16_t, void *, struct dhcp6opt **,
+    struct dhcp6opt *, int *));
+static ssize_t gethwid __P((char *, int, const char *, u_int16_t *));
+static char *sprint_uint64 __P((char *, int, u_int64_t));
+static char *sprint_auth __P((struct dhcp6_optinfo *));
+
+/* XXX */
+int
+rawop_count_list(head)
+	struct rawop_list *head;
+{
+	struct rawoption *op;
+	int i;
+
+	//dprintf(LOG_INFO, FNAME, "counting list at %p", (void*)head);
+	
+	for (i = 0, op = TAILQ_FIRST(head); op; op = TAILQ_NEXT(op, link)) {
+		i++;
+	}
+
+	return (i);
+}
+
+void
+rawop_clear_list(head)
+	struct rawop_list *head;
+{
+	struct rawoption *op;
+	
+	//dprintf(LOG_INFO, FNAME, "clearing %d rawops at %p", rawop_count_list(head), (void*)head);
+	
+	while ((op = TAILQ_FIRST(head)) != NULL) {
+		
+		//dprintf(LOG_INFO, FNAME, "  current op: %p link: %p", (void*)op, op->link);
+		TAILQ_REMOVE(head, op, link);
+		
+		if (op->data != NULL) {
+			d_printf(LOG_INFO, FNAME, "    freeing op data at %p", (void*)op->data);
+			free(op->data);	
+		}
+		free(op);	// Needed?
+	}	
+	return;
+}
 
 int
-dhcp6_copy_list(struct dhcp6_list *dst, struct dhcp6_list *src)
+rawop_copy_list(dst, src)
+	struct rawop_list *dst, *src;
+{
+	struct rawoption *op, *newop;	
+	
+	/*
+	d_printf(LOG_INFO, FNAME,
+		"  copying rawop list %p to %p (%d ops)",
+		(void*)src, (void*)dst, rawop_count_list(src));
+	*/
+	
+	for (op = TAILQ_FIRST(src); op; op = TAILQ_NEXT(op, link)) {
+		newop = NULL;
+		if ((newop = malloc(sizeof(*newop))) == NULL) {
+			d_printf(LOG_ERR, FNAME,
+				"failed to allocate memory for a new raw option");
+			goto fail;
+		}
+		memset(newop, 0, sizeof(*newop));
+
+		newop->opnum = op->opnum;
+		newop->datalen = op->datalen;	
+		newop->data = NULL;
+		
+		/* copy data */
+		if ((newop->data = malloc(newop->datalen)) == NULL) {
+			d_printf(LOG_ERR, FNAME,
+				"failed to allocate memory for new raw option data");
+			goto fail;
+		}
+		memcpy(newop->data, op->data, newop->datalen);
+		//dprintf(LOG_INFO, FNAME, "    copied %d bytes of data at %p", newop->datalen, (void*)newop->data);		
+			
+		TAILQ_INSERT_TAIL(dst, newop, link);
+	}
+	return (0);
+	
+  fail:
+	rawop_clear_list(dst);
+	return (-1);	
+}
+
+void
+rawop_move_list(dst, src)
+	struct rawop_list *dst, *src;
+{
+	struct rawoption *op;
+	/*
+	d_printf(LOG_INFO, FNAME,
+		"  moving rawop list of %d from %p to %p",
+		rawop_count_list(src), (void*)src, (void*)dst);	
+	*/
+	while ((op = TAILQ_FIRST(src)) != NULL) {
+		TAILQ_REMOVE(src, op, link);
+		TAILQ_INSERT_TAIL(dst, op, link);
+	}
+}
+
+
+int
+dhcp6_copy_list(dst, src)
+	struct dhcp6_list *dst, *src;
 {
 	struct dhcp6_listval *ent;
 
@@ -133,7 +233,8 @@ dhcp6_copy_list(struct dhcp6_list *dst, struct dhcp6_list *src)
 }
 
 void
-dhcp6_move_list(struct dhcp6_list *dst, struct dhcp6_list *src)
+dhcp6_move_list(dst, src)
+	struct dhcp6_list *dst, *src;
 {
 	struct dhcp6_listval *v;
 
@@ -144,7 +245,8 @@ dhcp6_move_list(struct dhcp6_list *dst, struct dhcp6_list *src)
 }
 
 void
-dhcp6_clear_list(struct dhcp6_list *head)
+dhcp6_clear_list(head)
+	struct dhcp6_list *head;
 {
 	struct dhcp6_listval *v;
 
@@ -157,7 +259,8 @@ dhcp6_clear_list(struct dhcp6_list *head)
 }
 
 static int
-dhcp6_count_list(struct dhcp6_list *head)
+dhcp6_count_list(head)
+	struct dhcp6_list *head;
 {
 	struct dhcp6_listval *v;
 	int i;
@@ -169,7 +272,8 @@ dhcp6_count_list(struct dhcp6_list *head)
 }
 
 void
-dhcp6_clear_listval(struct dhcp6_listval *lv)
+dhcp6_clear_listval(lv)
+	struct dhcp6_listval *lv;
 {
 	dhcp6_clear_list(&lv->sublist);
 	switch (lv->type) {
@@ -187,8 +291,11 @@ dhcp6_clear_listval(struct dhcp6_listval *lv)
  * VAL.  It also does not care about sublists.
  */
 struct dhcp6_listval *
-dhcp6_find_listval(struct dhcp6_list *head, dhcp6_listval_type_t type,
-    void *val, int option)
+dhcp6_find_listval(head, type, val, option)
+	struct dhcp6_list *head;
+	dhcp6_listval_type_t type;
+	void *val;
+	int option;
 {
 	struct dhcp6_listval *lv;
 
@@ -202,7 +309,7 @@ dhcp6_find_listval(struct dhcp6_list *head, dhcp6_listval_type_t type,
 				return (lv);
 			break;
 		case DHCP6_LISTVAL_STCODE:
-			if (lv->val_num16 == *(uint16_t *)val)
+			if (lv->val_num16 == *(u_int16_t *)val)
 				return (lv);
 			break;
 		case DHCP6_LISTVAL_ADDR6:
@@ -249,8 +356,10 @@ dhcp6_find_listval(struct dhcp6_list *head, dhcp6_listval_type_t type,
 }
 
 struct dhcp6_listval *
-dhcp6_add_listval(struct dhcp6_list *head, dhcp6_listval_type_t type,
-    void *val, struct dhcp6_list *sublist)
+dhcp6_add_listval(head, type, val, sublist)
+	struct dhcp6_list *head, *sublist;
+	dhcp6_listval_type_t type;
+	void *val;
 {
 	struct dhcp6_listval *lv = NULL;
 
@@ -268,7 +377,7 @@ dhcp6_add_listval(struct dhcp6_list *head, dhcp6_listval_type_t type,
 		lv->val_num = *(int *)val;
 		break;
 	case DHCP6_LISTVAL_STCODE:
-		lv->val_num16 = *(uint16_t *)val;
+		lv->val_num16 = *(u_int16_t *)val;
 		break;
 	case DHCP6_LISTVAL_ADDR6:
 		lv->val_addr6 = *(struct in6_addr *)val;
@@ -308,7 +417,8 @@ dhcp6_add_listval(struct dhcp6_list *head, dhcp6_listval_type_t type,
 }
 
 int
-dhcp6_vbuf_copy(struct dhcp6_vbuf *dst, struct dhcp6_vbuf *src)
+dhcp6_vbuf_copy(dst, src)
+	struct dhcp6_vbuf *dst, *src;
 {
 	dst->dv_buf = malloc(src->dv_len);
 	if (dst->dv_buf == NULL)
@@ -321,7 +431,8 @@ dhcp6_vbuf_copy(struct dhcp6_vbuf *dst, struct dhcp6_vbuf *src)
 }
 
 void
-dhcp6_vbuf_free(struct dhcp6_vbuf *vbuf)
+dhcp6_vbuf_free(vbuf)
+	struct dhcp6_vbuf *vbuf;
 {
 	free(vbuf->dv_buf);
 
@@ -330,7 +441,8 @@ dhcp6_vbuf_free(struct dhcp6_vbuf *vbuf)
 }
 
 int
-dhcp6_vbuf_cmp(struct dhcp6_vbuf *vb1, struct dhcp6_vbuf *vb2)
+dhcp6_vbuf_cmp(vb1, vb2)
+	struct dhcp6_vbuf *vb1, *vb2;
 {
 	if (vb1->dv_len != vb2->dv_len)
 		return (vb1->dv_len - vb2->dv_len);
@@ -339,18 +451,20 @@ dhcp6_vbuf_cmp(struct dhcp6_vbuf *vb1, struct dhcp6_vbuf *vb2)
 }
 
 static int
-dhcp6_get_addr(int optlen, void *cp, dhcp6_listval_type_t type,
-    struct dhcp6_list *list)
+dhcp6_get_addr(optlen, cp, type, list)
+	int optlen;
+	void *cp;
+	dhcp6_listval_type_t type;
+	struct dhcp6_list *list;
 {
-	char *val;
+	void *val;
 
 	if (optlen % sizeof(struct in6_addr) || optlen == 0) {
 		d_printf(LOG_INFO, FNAME,
 		    "malformed DHCP option: type %d, len %d", type, optlen);
 		return -1;
 	}
-	for (val = (char *)cp; val < (char *)cp + optlen;
-	    val += sizeof(struct in6_addr)) {
+	for (val = cp; val < cp + optlen; val += sizeof(struct in6_addr)) {
 		struct in6_addr valaddr;
 
 		memcpy(&valaddr, val, sizeof(valaddr));
@@ -380,27 +494,30 @@ dhcp6_set_addr(type, list, p, optep, len)
 	int *len;
 {
 	struct in6_addr *in6;
+	char *tmpbuf;
 	struct dhcp6_listval *d;
 	int optlen;
 
 	if (TAILQ_EMPTY(list))
 		return 0;
 
+	tmpbuf = NULL;
 	optlen = dhcp6_count_list(list) * sizeof(struct in6_addr);
-	if ((in6 = malloc(optlen)) == NULL) {
+	if ((tmpbuf = malloc(optlen)) == NULL) {
 		d_printf(LOG_ERR, FNAME,
 		    "memory allocation failed for %s options",
 		    dhcp6optstr(type));
 		return -1;
 	}
+	in6 = (struct in6_addr *)tmpbuf;
 	for (d = TAILQ_FIRST(list); d; d = TAILQ_NEXT(d, link), in6++)
 		memcpy(in6, &d->val_addr6, sizeof(*in6));
-	if (copy_option(type, optlen, (char *)in6, p, optep, len) != 0) {
-		free(in6);
+	if (copy_option(type, optlen, tmpbuf, p, optep, len) != 0) {
+		free(tmpbuf);
 		return -1;
 	}
 
-	free(in6);
+	free(tmpbuf);
 	return 0;
 }
 
@@ -411,15 +528,15 @@ dhcp6_get_domain(optlen, cp, type, list)
 	dhcp6_listval_type_t type;
 	struct dhcp6_list *list;
 {
-	char *val;
+	void *val;
 
-	val = (char *)cp;
-	while (val < (char *)cp + optlen) {
+	val = cp;
+	while (val < cp + optlen) {
 		struct dhcp6_vbuf vb;
 		char name[MAXDNAME + 1];
 
 		if (dnsdecode((u_char **)(void *)&val,
-		    (u_char *)((char *)cp + optlen), name, sizeof(name)) == NULL) {
+		    (u_char *)(cp + optlen), name, sizeof(name)) == NULL) {
 			d_printf(LOG_INFO, FNAME, "failed to "
 			    "decode a %s domain name",
 			    dhcp6optstr(type));
@@ -612,11 +729,11 @@ copy_authparam(authparam)
  * XXX: is there any standard for this?
  */
 #if (BYTE_ORDER == LITTLE_ENDIAN)
-static __inline uint64_t
-ntohq(uint64_t x)
+static __inline u_int64_t
+ntohq(u_int64_t x)
 {
-	return (uint64_t)ntohl((uint32_t)(x >> 32)) |
-	    (int64_t)ntohl((uint32_t)(x & 0xffffffff)) << 32;
+	return (u_int64_t)ntohl((u_int32_t)(x >> 32)) |
+	    (int64_t)ntohl((u_int32_t)(x & 0xffffffff)) << 32;
 }
 #else	/* (BYTE_ORDER == LITTLE_ENDIAN) */
 #define ntohq(x) (x)
@@ -625,7 +742,7 @@ ntohq(uint64_t x)
 int
 dhcp6_auth_replaycheck(method, prev, current)
 	int method;
-	uint64_t prev, current;
+	u_int64_t prev, current;
 {
 	char bufprev[] = "ffff ffff ffff ffff";
 	char bufcurrent[] = "ffff ffff ffff ffff";
@@ -715,7 +832,7 @@ getifaddr(addr, ifnam, prefix, plen, strong, ignoreflags)
 			memset(&m, 0, sizeof(m));
 			memset(&m, 0xff, plen / 8);
 			m.s6_addr[plen / 8] = (0xff00 >> (plen % 8)) & 0xff;
-			for (i = 0; i < (int)sizeof(a); i++)
+			for (i = 0; i < sizeof(a); i++)
 				a.s6_addr[i] &= m.s6_addr[i];
 
 			if (memcmp(&a, prefix, plen / 8) != 0 ||
@@ -756,7 +873,7 @@ getifidfromaddr(addr, ifidp)
 		if (ifa->ifa_addr->sa_family != AF_INET6)
 			continue;
 
-		sa6 = (struct sockaddr_in6 *)(void *)ifa->ifa_addr;
+		sa6 = (struct sockaddr_in6 *)ifa->ifa_addr;
 		if (IN6_ARE_ADDR_EQUAL(addr, &sa6->sin6_addr))
 			break;
 	}
@@ -805,11 +922,11 @@ transmit_sa(s, sa, buf, len)
 	char *buf;
 	size_t len;
 {
-	ssize_t error;
+	int error;
 
 	error = sendto(s, buf, len, 0, sa, sysdep_sa_len(sa));
 
-	return (error != (ssize_t)len) ? -1 : 0;
+	return (error != len) ? -1 : 0;
 }
 
 long
@@ -953,7 +1070,7 @@ in6_matchflags(addr, ifnam, flags)
 	}
 	memset(&ifr6, 0, sizeof(ifr6));
 	strncpy(ifr6.ifr_name, ifnam, sizeof(ifr6.ifr_name));
-	ifr6.ifr_addr = *(struct sockaddr_in6 *)(void *)addr;
+	ifr6.ifr_addr = *(struct sockaddr_in6 *)addr;
 
 	if (ioctl(s, SIOCGIFAFLAG_IN6, &ifr6) < 0) {
 		warn("in6_matchflags: ioctl(SIOCGIFAFLAG_IN6, %s)",
@@ -972,11 +1089,11 @@ in6_matchflags(addr, ifnam, flags)
 
 int
 get_duid(idfile, duid)
-	const char *idfile;
+	char *idfile;
 	struct duid *duid;
 {
 	FILE *fp = NULL;
-	uint16_t len = 0, hwtype;
+	u_int16_t len = 0, hwtype;
 	struct dhcp6opt_duid_type1 *dp; /* we only support the type1 DUID */
 	char tmpbuf[256];	/* DUID should be no more than 256 bytes */
 
@@ -1019,13 +1136,13 @@ get_duid(idfile, duid)
 		    "extracted an existing DUID from %s: %s",
 		    idfile, duidstr(duid));
 	} else {
-		uint64_t t64;
+		u_int64_t t64;
 
 		dp = (struct dhcp6opt_duid_type1 *)duid->duid_id;
 		dp->dh6_duid1_type = htons(1); /* type 1 */
 		dp->dh6_duid1_hwtype = htons(hwtype);
 		/* time is Jan 1, 2000 (UTC), modulo 2^32 */
-		t64 = (uint64_t)(time(NULL) - 946684800);
+		t64 = (u_int64_t)(time(NULL) - 946684800);
 		dp->dh6_duid1_time = htonl((u_long)(t64 & 0xffffffff));
 		memcpy((void *)(dp + 1), tmpbuf, (len - sizeof(*dp)));
 
@@ -1070,12 +1187,12 @@ get_duid(idfile, duid)
 #ifdef __sun__
 struct hwparms {
 	char *buf;
-	uint16_t *hwtypep;
+	u_int16_t *hwtypep;
 	ssize_t retval;
 };
 
 static ssize_t
-getifhwaddr(const char *ifname, char *buf, uint16_t *hwtypep, int ppa)
+getifhwaddr(const char *ifname, char *buf, u_int16_t *hwtypep, int ppa)
 {
 	int fd, flags;
 	char fname[MAXPATHLEN], *cp;
@@ -1203,7 +1320,7 @@ gethwid(buf, len, ifname, hwtypep)
 	char *buf;
 	int len;
 	const char *ifname;
-	uint16_t *hwtypep;
+	u_int16_t *hwtypep;
 {
 	struct ifaddrs *ifa, *ifap;
 #ifdef __KAME__
@@ -1248,7 +1365,7 @@ gethwid(buf, len, ifname, hwtypep)
 		if (ifa->ifa_addr->sa_family != AF_LINK)
 			continue;
 
-		sdl = (struct sockaddr_dl *)(void *)ifa->ifa_addr;
+		sdl = (struct sockaddr_dl *)ifa->ifa_addr;
 		if (len < 2 + sdl->sdl_alen)
 			goto fail;
 		/*
@@ -1319,6 +1436,9 @@ dhcp6_init_options(optinfo)
 	TAILQ_INIT(&optinfo->bcmcs_list);
 	TAILQ_INIT(&optinfo->bcmcsname_list);
 
+	/* XXX */
+	TAILQ_INIT(&optinfo->rawops);
+
 	optinfo->authproto = DHCP6_AUTHPROTO_UNDEF;
 	optinfo->authalgorithm = DHCP6_AUTHALG_UNDEF;
 	optinfo->authrdm = DHCP6_AUTHRDM_UNDEF;
@@ -1361,6 +1481,9 @@ dhcp6_clear_options(optinfo)
 
 	if (optinfo->ifidopt_id != NULL)
 		free(optinfo->ifidopt_id);
+
+	/* XXX */
+	rawop_clear_list(&optinfo->rawops);
 
 	dhcp6_init_options(optinfo);
 }
@@ -1410,6 +1533,9 @@ dhcp6_copy_options(dst, src)
 	dst->elapsed_time = src->elapsed_time;
 	dst->refreshtime = src->refreshtime;
 	dst->pref = src->pref;
+
+	/* XXX */
+	rawop_copy_list(&dst->rawops, &src->rawops);
 
 	if (src->relaymsg_msg != NULL) {
 		if ((dst->relaymsg_msg = malloc(src->relaymsg_len)) == NULL)
@@ -1470,14 +1596,17 @@ dhcp6_get_options(p, ep, optinfo)
 {
 	struct dhcp6opt *np, opth;
 	int i, opt, optlen, reqopts, num;
-	uint16_t num16;
+	u_int16_t num16;
 	char *bp, *cp, *val;
-	uint16_t val16;
-	uint32_t val32;
+	u_int16_t val16;
+	u_int32_t val32;
 	struct dhcp6opt_ia optia;
 	struct dhcp6_ia ia;
 	struct dhcp6_list sublist;
 	int authinfolen;
+
+	/* XXX */
+	struct rawoption *rawop;
 
 	bp = (char *)p;
 	for (; p + 1 <= ep; p = np) {
@@ -1528,7 +1657,7 @@ dhcp6_get_options(p, ep, optinfo)
 			}
 			break;
 		case DH6OPT_STATUS_CODE:
-			if (optlen < (int)sizeof(uint16_t))
+			if (optlen < sizeof(u_int16_t))
 				goto malformed;
 			memcpy(&val16, cp, sizeof(val16));
 			num16 = ntohs(val16);
@@ -1550,10 +1679,10 @@ dhcp6_get_options(p, ep, optinfo)
 				goto malformed;
 			reqopts = optlen / 2;
 			for (i = 0, val = cp; i < reqopts;
-			     i++, val += sizeof(uint16_t)) {
-				uint16_t opttype;
+			     i++, val += sizeof(u_int16_t)) {
+				u_int16_t opttype;
 
-				memcpy(&opttype, val, sizeof(uint16_t));
+				memcpy(&opttype, val, sizeof(u_int16_t));
 				num = (int)ntohs(opttype);
 
 				d_printf(LOG_DEBUG, "",
@@ -1595,7 +1724,7 @@ dhcp6_get_options(p, ep, optinfo)
 			memcpy(&val16, cp, sizeof(val16));
 			val16 = ntohs(val16);
 			d_printf(LOG_DEBUG, "", "  elapsed time: %lu",
-			    (uint32_t)val16);
+			    (u_int32_t)val16);
 			if (optinfo->elapsed_time !=
 			    DH6OPT_ELAPSED_TIME_UNDEF) {
 				d_printf(LOG_INFO, FNAME,
@@ -1610,7 +1739,7 @@ dhcp6_get_options(p, ep, optinfo)
 			optinfo->relaymsg_len = optlen;
 			break;
 		case DH6OPT_AUTH:
-			if (optlen < (int)sizeof(struct dhcp6opt_auth) - 4)
+			if (optlen < sizeof(struct dhcp6opt_auth) - 4)
 				goto malformed;
 
 			/*
@@ -1643,7 +1772,7 @@ dhcp6_get_options(p, ep, optinfo)
 				}
 				/* XXX: should we reject an empty realm? */
 				if (authinfolen <
-				    (int)sizeof(optinfo->delayedauth_keyid) + 16) {
+				    sizeof(optinfo->delayedauth_keyid) + 16) {
 					goto malformed;
 				}
 
@@ -1679,6 +1808,15 @@ dhcp6_get_options(p, ep, optinfo)
 			case DHCP6_AUTHPROTO_RECONFIG:
 				break;
 #endif
+			/* XXX */
+			case 0:
+				// Discard auth
+				d_printf(LOG_DEBUG, FNAME, "  Discarding null authentication");
+				optinfo->authproto = DHCP6_AUTHPROTO_UNDEF;
+				optinfo->authalgorithm = DHCP6_AUTHALG_UNDEF;
+				optinfo->authrdm = DHCP6_AUTHRDM_UNDEF;
+				break;
+
 			default:
 				d_printf(LOG_INFO, FNAME,
 				    "unsupported authentication protocol: %d",
@@ -1854,6 +1992,16 @@ dhcp6_get_options(p, ep, optinfo)
 			dhcp6_clear_list(&sublist);
 
 			break;
+			
+		/* XX */		
+		case DHCPOPT_RAW:
+			rawop = (struct rawoption *) cp;
+			d_printf(LOG_DEBUG, FNAME,
+				"raw option: %d",
+				rawop->opnum);				
+			TAILQ_INSERT_TAIL(&optinfo->rawops, rawop, link);			
+			break;			
+
 		default:
 			/* no option specific behavior */
 			d_printf(LOG_INFO, FNAME,
@@ -1909,7 +2057,7 @@ dnsdecode(sp, ep, buf, bufsiz)
 			if (!isprint(*cp)) /* we don't accept non-printables */
 				return (NULL);
 			l = snprintf(tmpbuf, sizeof(tmpbuf), "%c" , *cp);
-			if (l >= (int)sizeof(tmpbuf) || l < 0)
+			if (l >= sizeof(tmpbuf) || l < 0)
 				return (NULL);
 			if (strlcat(buf, tmpbuf, bufsiz) >= bufsiz)
 				return (NULL); /* result overrun */
@@ -2126,10 +2274,10 @@ static char *
 sprint_uint64(buf, buflen, i64)
 	char *buf;
 	int buflen;
-	uint64_t i64;
+	u_int64_t i64;
 {
-	uint16_t rd0, rd1, rd2, rd3;
-	uint16_t *ptr = (uint16_t *)(void *)&i64;
+	u_int16_t rd0, rd1, rd2, rd3;
+	u_int16_t *ptr = (u_int16_t *)(void *)&i64;
 
 	rd0 = ntohs(*ptr++);
 	rd1 = ntohs(*ptr++);
@@ -2146,12 +2294,9 @@ sprint_auth(optinfo)
 	struct dhcp6_optinfo *optinfo;
 {
 	static char ret[1024];	/* XXX: thread unsafe */
-	const char *proto;
-	char proto0[] = "unknown(255)";
-	const char *alg;
-	char alg0[] = "unknown(255)";
-	const char *rdm;
-	char rdm0[] = "unknown(255)";
+	char *proto, proto0[] = "unknown(255)";
+	char *alg, alg0[] = "unknown(255)";
+	char *rdm, rdm0[] = "unknown(255)";
 	char rd[] = "ffff ffff ffff ffff";
 
 	switch (optinfo->authproto) {
@@ -2197,12 +2342,15 @@ sprint_auth(optinfo)
 }
 
 static int
-copy_option(uint16_t type, uint16_t len, void *val,
-    struct dhcp6opt **optp, struct dhcp6opt *ep, int *totallenp)
+copy_option(type, len, val, optp, ep, totallenp)
+	u_int16_t type, len;
+	void *val;
+	struct dhcp6opt **optp, *ep;
+	int *totallenp;
 {
 	struct dhcp6opt *opt = *optp, opth;
 
-	if ((char *)ep - (char *)optp < (intptr_t)(len + sizeof(struct dhcp6opt))) {
+	if ((void *)ep - (void *)optp < len + sizeof(struct dhcp6opt)) {
 		d_printf(LOG_INFO, FNAME,
 		    "option buffer short for %s", dhcp6optstr(type));
 		return (-1);
@@ -2230,6 +2378,8 @@ dhcp6_set_options(type, optbp, optep, optinfo)
 	struct dhcp6_listval *stcode, *op;
 	int len = 0, optlen;
 	char *tmpbuf = NULL;
+	/* XXX */
+	struct rawoption *rawop;
 
 	if (optinfo->clientID.duid_len) {
 		if (copy_option(DH6OPT_CLIENTID, optinfo->clientID.duid_len,
@@ -2247,13 +2397,15 @@ dhcp6_set_options(type, optbp, optep, optinfo)
 
 	for (op = TAILQ_FIRST(&optinfo->iana_list); op;
 	    op = TAILQ_NEXT(op, link)) {
+		int optlen;
+
 		tmpbuf = NULL;
 		if ((optlen = copyout_option(NULL, NULL, op)) < 0) {
 			d_printf(LOG_INFO, FNAME,
 			    "failed to count option length");
 			goto fail;
 		}
-		if ((char *)optep - (char *)p < (intptr_t)optlen) {
+		if ((void *)optep - (void *)p < optlen) {
 			d_printf(LOG_INFO, FNAME, "short buffer");
 			goto fail;
 		}
@@ -2282,7 +2434,7 @@ dhcp6_set_options(type, optbp, optep, optinfo)
 	}
 
 	if (optinfo->pref != DH6OPT_PREF_UNDEF) {
-		uint8_t p8 = (uint8_t)optinfo->pref;
+		u_int8_t p8 = (u_int8_t)optinfo->pref;
 
 		if (copy_option(DH6OPT_PREFERENCE, sizeof(p8), &p8, &p,
 		    optep, &len) != 0) {
@@ -2291,7 +2443,7 @@ dhcp6_set_options(type, optbp, optep, optinfo)
 	}
 
 	if (optinfo->elapsed_time != DH6OPT_ELAPSED_TIME_UNDEF) {
-		uint16_t p16 = (uint16_t)optinfo->elapsed_time;
+		u_int16_t p16 = (u_int16_t)optinfo->elapsed_time;
 
 		p16 = htons(p16);
 		if (copy_option(DH6OPT_ELAPSED_TIME, sizeof(p16), &p16, &p,
@@ -2302,7 +2454,7 @@ dhcp6_set_options(type, optbp, optep, optinfo)
 
 	for (stcode = TAILQ_FIRST(&optinfo->stcode_list); stcode;
 	     stcode = TAILQ_NEXT(stcode, link)) {
-		uint16_t code;
+		u_int16_t code;
 
 		code = htons(stcode->val_num16);
 		if (copy_option(DH6OPT_STATUS_CODE, sizeof(code), &code, &p,
@@ -2313,17 +2465,19 @@ dhcp6_set_options(type, optbp, optep, optinfo)
 
 	if (!TAILQ_EMPTY(&optinfo->reqopt_list)) {
 		struct dhcp6_listval *opt;
-		uint16_t *valp, *valp0;
+		u_int16_t *valp;
 		int buflen;
 
+		tmpbuf = NULL;
 		buflen = dhcp6_count_list(&optinfo->reqopt_list) *
-			sizeof(uint16_t);
-		if ((valp0 = valp = malloc(buflen)) == NULL) {
+			sizeof(u_int16_t);
+		if ((tmpbuf = malloc(buflen)) == NULL) {
 			d_printf(LOG_ERR, FNAME,
 			    "memory allocation failed for options");
 			goto fail;
 		}
 		optlen = 0;
+		valp = (u_int16_t *)tmpbuf;
 		for (opt = TAILQ_FIRST(&optinfo->reqopt_list); opt;
 		     opt = TAILQ_NEXT(opt, link)) {
 			/*
@@ -2338,16 +2492,17 @@ dhcp6_set_options(type, optbp, optep, optinfo)
 				    "for %s", dhcp6msgstr(type));
 			}
 
-			*valp = htons((uint16_t)opt->val_num);
+			*valp = htons((u_int16_t)opt->val_num);
 			valp++;
-			optlen += sizeof(uint16_t);
+			optlen += sizeof(u_int16_t);
 		}
 		if (optlen > 0 &&
-		    copy_option(DH6OPT_ORO, optlen, (void *)valp0, &p,
+		    copy_option(DH6OPT_ORO, optlen, tmpbuf, &p,
 		    optep, &len) != 0) {
 			goto fail;
 		}
-		free(valp0);
+		free(tmpbuf);
+		tmpbuf = NULL;
 	}
 
 	if (dhcp6_set_domain(DH6OPT_SIP_SERVER_D, &optinfo->sipname_list,
@@ -2396,13 +2551,15 @@ dhcp6_set_options(type, optbp, optep, optinfo)
 
 	for (op = TAILQ_FIRST(&optinfo->iapd_list); op;
 	    op = TAILQ_NEXT(op, link)) {
+		int optlen;
+
 		tmpbuf = NULL;
 		if ((optlen = copyout_option(NULL, NULL, op)) < 0) {
 			d_printf(LOG_INFO, FNAME,
 			    "failed to count option length");
 			goto fail;
 		}
-		if ((char *)optep - (char *)p < (intptr_t)optlen) {
+		if ((void *)optep - (void *)p < optlen) {
 			d_printf(LOG_INFO, FNAME, "short buffer");
 			goto fail;
 		}
@@ -2438,7 +2595,7 @@ dhcp6_set_options(type, optbp, optep, optinfo)
 	}
 
 	if (optinfo->refreshtime != DH6OPT_REFRESHTIME_UNDEF) {
-		uint32_t p32 = (uint32_t)optinfo->refreshtime;
+		u_int32_t p32 = (u_int32_t)optinfo->refreshtime;
 
 		p32 = htonl(p32);
 		if (copy_option(DH6OPT_REFRESHTIME, sizeof(p32), &p32, &p,
@@ -2446,6 +2603,21 @@ dhcp6_set_options(type, optbp, optep, optinfo)
 			goto fail;
 		}
 	}
+	/* XXX */
+	for (rawop = TAILQ_FIRST(&optinfo->rawops); rawop;
+	    rawop = TAILQ_NEXT(rawop, link)) {
+			
+		d_printf(LOG_DEBUG, FNAME,
+			"  raw option %d length %d at %p",
+			rawop->opnum, rawop->datalen, (void*)rawop);
+			
+		if (copy_option(rawop->opnum, rawop->datalen,
+			rawop->data, &p,
+		    optep, &len) != 0) {
+			goto fail;
+		}
+	}
+	
 
 	if (optinfo->authproto != DHCP6_AUTHPROTO_UNDEF) {
 		struct dhcp6opt_auth *auth;
@@ -2480,14 +2652,14 @@ dhcp6_set_options(type, optbp, optep, optinfo)
 
 		memset(auth, 0, authlen);
 		/* copy_option will take care of type and len later */
-		auth->dh6_auth_proto = (uint8_t)optinfo->authproto;
-		auth->dh6_auth_alg = (uint8_t)optinfo->authalgorithm;
-		auth->dh6_auth_rdm = (uint8_t)optinfo->authrdm;
+		auth->dh6_auth_proto = (u_int8_t)optinfo->authproto;
+		auth->dh6_auth_alg = (u_int8_t)optinfo->authalgorithm;
+		auth->dh6_auth_rdm = (u_int8_t)optinfo->authrdm;
 		memcpy(auth->dh6_auth_rdinfo, &optinfo->authrd,
 		    sizeof(auth->dh6_auth_rdinfo));
 
 		if (!(optinfo->authflags & DHCP6OPT_AUTHFLAG_NOINFO)) {
-			uint32_t p32;
+			u_int32_t p32;
 
 			switch (optinfo->authproto) {
 			case DHCP6_AUTHPROTO_DELAYED:
@@ -2798,7 +2970,7 @@ dhcp6_reset_timer(ev)
 	struct dhcp6_event *ev;
 {
 	double n, r;
-	const char *statestr;
+	char *statestr;
 	struct timeval interval;
 
 	switch(ev->state) {
@@ -2901,13 +3073,13 @@ get_rdvalue(rdm, rdvalue, rdsize)
 #else
 	struct timeval tv;
 #endif
-	uint32_t u32, l32;
+	u_int32_t u32, l32;
 
 	if (rdm != DHCP6_AUTHRDM_MONOCOUNTER) {
 		d_printf(LOG_INFO, FNAME, "unsupported RDM (%d)", rdm);
 		return (-1);
 	}
-	if (rdsize != sizeof(uint64_t)) {
+	if (rdsize != sizeof(u_int64_t)) {
 		d_printf(LOG_INFO, FNAME, "unsupported RD size (%d)", rdsize);
 		return (-1);
 	}
@@ -2919,21 +3091,21 @@ get_rdvalue(rdm, rdvalue, rdsize)
 		return (-1);
 	}
 
-	u32 = (uint32_t)tp.tv_sec;
+	u32 = (u_int32_t)tp.tv_sec;
 	u32 += JAN_1970;
 
 	nsec = (double)tp.tv_nsec / 1e9 * 0x100000000ULL;
 	/* nsec should be smaller than 2^32 */
-	l32 = (uint32_t)nsec;
+	l32 = (u_int32_t)nsec;
 #else
 	if (gettimeofday(&tv, NULL) != 0) {
 		d_printf(LOG_WARNING, FNAME, "gettimeofday failed: %s",
 		    strerror(errno));
 		return (-1);
 	}
-	u32 = (uint32_t)tv.tv_sec;
+	u32 = (u_int32_t)tv.tv_sec;
 	u32 += JAN_1970;
-	l32 = (uint32_t)tv.tv_usec;
+	l32 = (u_int32_t)tv.tv_usec;
 #endif /* HAVE_CLOCK_GETTIME */
 
 	u32 = htonl(u32);
@@ -2945,7 +3117,7 @@ get_rdvalue(rdm, rdvalue, rdsize)
 	return (0);
 }
 
-const char *
+char *
 dhcp6optstr(type)
 	int type;
 {
@@ -3026,14 +3198,18 @@ dhcp6optstr(type)
 	case DH6OPT_SUBSCRIBER_ID:
 		return ("subscriber ID");
 	case DH6OPT_CLIENT_FQDN:
-		return ("client FQDN");
+		return ("client FQDN");		
+	/* XXX */
+	case DHCPOPT_RAW:
+		return ("raw");
+
 	default:
 		snprintf(genstr, sizeof(genstr), "opt_%d", type);
 		return (genstr);
 	}
 }
 
-const char *
+char *
 dhcp6msgstr(type)
 	int type;
 {
@@ -3075,8 +3251,9 @@ dhcp6msgstr(type)
 	}
 }
 
-const char *
-dhcp6_stcodestr(uint16_t code)
+char *
+dhcp6_stcodestr(code)
+	u_int16_t code;
 {
 	static char genstr[sizeof("code255") + 1]; /* XXX thread unsafe */
 
@@ -3108,8 +3285,7 @@ char *
 duidstr(duid)
 	struct duid *duid;
 {
-	size_t i;
-	int n;
+	int i, n;
 	char *cp, *ep;
 	static char duidstr[sizeof("xx:") * 128 + sizeof("...")];
 
@@ -3128,7 +3304,7 @@ duidstr(duid)
 	return (duidstr);
 }
 
-const char *dhcp6_event_statestr(ev)
+char *dhcp6_event_statestr(ev)
 	struct dhcp6_event *ev;
 {
 	switch(ev->state) {
@@ -3240,7 +3416,7 @@ ifaddrconf(cmd, ifname, addr, plen, pltime, vltime)
 	struct lifreq req;
 #endif
 	unsigned long ioctl_cmd;
-	const char *cmdstr;
+	char *cmdstr;
 	int s;			/* XXX overhead */
 
 	switch(cmd) {
@@ -3363,42 +3539,6 @@ safefile(path)
 		    path, (s.st_mode & S_IFMT));
 		return (-1);
 	}
-
-	return (0);
-}
-
-int
-get_val32(char **bpp, int *lenp, uint32_t *valp)
-{
-	char *bp = *bpp;
-	size_t len = (size_t)*lenp;
-	uint32_t i32;
-
-	if (len < sizeof(*valp))
-		return (-1);
-
-	memcpy(&i32, bp, sizeof(i32));
-	*valp = ntohl(i32);
-
-	*bpp = bp + sizeof(*valp);
-	*lenp = len - sizeof(*valp);
-
-	return (0);
-}
-
-int
-get_val(char **bpp, int *lenp, void *valp, size_t vallen)
-{
-	char *bp = *bpp;
-	size_t len = (size_t)*lenp;
-
-	if (len < vallen)
-		return (-1);
-
-	memcpy(valp, bp, vallen);
-
-	*bpp = bp + vallen;
-	*lenp = len - vallen;
 
 	return (0);
 }

--- a/config.h
+++ b/config.h
@@ -29,17 +29,14 @@
  * SUCH DAMAGE.
  */
 
-#ifndef	_CONFIG_H_
-#define	_CONFIG_H_
-
 /* definitions of tail-queue types */
 TAILQ_HEAD(ia_conflist, ia_conf);
 TAILQ_HEAD(pifc_list, prefix_ifconf);
 
 struct dhcp6_poolspec {
 	char* name;
-	uint32_t pltime;
-	uint32_t vltime;
+	u_int32_t pltime;
+	u_int32_t vltime;
 };
 
 struct dhcp6_range {
@@ -69,7 +66,7 @@ struct dhcp6_if {
 	/* static parameters of the interface */
 	char *ifname;
 	unsigned int ifid;
-	uint32_t linkid;	/* to send link-local packets */
+	u_int32_t linkid;	/* to send link-local packets */
 	/* multiple global address configuration is not supported now */
 	struct in6_addr addr; 	/* global address */
 
@@ -82,6 +79,10 @@ struct dhcp6_if {
 	int server_pref;	/* server preference (server only) */
 	struct dhcp6_poolspec pool;	/* address pool (server only) */
 	char *scriptpath;	/* path to config script (client only) */
+
+	/* XXX */
+	struct duid duid;
+	struct rawop_list rawops;
 
 	struct dhcp6_list reqopt_list;
 	struct ia_conflist iaconf_list;
@@ -102,7 +103,7 @@ struct authparam {
 	int flags;
 #define AUTHPARAM_FLAGS_NOPREVRD	0x1
 
-	uint64_t prevrd;	/* previous RD value provided by the peer */
+	u_int64_t prevrd;	/* previous RD value provided by the peer */
 };
 
 struct dhcp6_event {
@@ -123,7 +124,7 @@ struct dhcp6_event {
 	long max_retrans_dur;
 	int timeouts;		/* number of timeouts */
 
-	uint32_t xid;		/* current transaction ID */
+	u_int32_t xid;		/* current transaction ID */
 	int state;
 
 	/* list of known servers */
@@ -145,7 +146,7 @@ struct dhcp6_eventdata {
 	dhcp6_eventdata_t type;
 	void *data;
 
-	void (*destructor)(struct dhcp6_eventdata *);
+	void (*destructor) __P((struct dhcp6_eventdata *));
 	void *privdata;
 };
 
@@ -173,7 +174,7 @@ struct prefix_ifconf {
 
 	char *ifname;		/* interface name such as ne0 */
 	int sla_len;		/* SLA ID length in bits */
-	uint32_t sla_id;	/* need more than 32bits? */
+	u_int32_t sla_id;	/* need more than 32bits? */
 	int ifid_len;		/* interface ID length in bits */
 	int ifid_type;		/* EUI-64 and manual (unused?) */
 	char ifid[16];		/* Interface ID, up to 128bits */
@@ -186,7 +187,7 @@ struct ia_conf {
 	TAILQ_ENTRY(ia_conf) link;
 	/*struct ia_conf *next;*/
 	iatype_t type;
-	uint32_t iaid;
+	u_int32_t iaid;
 
 	TAILQ_HEAD(, ia) iadata; /* struct ia is an opaque type */
 
@@ -230,7 +231,7 @@ struct host_conf {
 	struct keyinfo *delayedkey;
 	/* previous replay detection value from the client */
 	int saw_previous_rd;	/* if we remember the previous value */
-	uint64_t previous_rd;
+	u_int64_t previous_rd;
 };
 
 /* DHCPv6 authentication information */
@@ -282,7 +283,10 @@ enum { DECL_SEND, DECL_ALLOW, DECL_INFO_ONLY, DECL_REQUEST, DECL_DUID,
        IACONF_PIF, IACONF_PREFIX, IACONF_ADDR,
        DHCPOPT_SIP, DHCPOPT_SIPNAME,
        AUTHPARAM_PROTO, AUTHPARAM_ALG, AUTHPARAM_RDM, AUTHPARAM_KEY,
-       KEYPARAM_REALM, KEYPARAM_KEYID, KEYPARAM_SECRET, KEYPARAM_EXPIRE };
+      KEYPARAM_REALM, KEYPARAM_KEYID, KEYPARAM_SECRET, KEYPARAM_EXPIRE,
+       /* XXX */
+       DHCPOPT_RAW
+    };
 
 typedef enum {DHCP6_MODE_SERVER, DHCP6_MODE_CLIENT, DHCP6_MODE_RELAY }
 dhcp6_mode_t;
@@ -305,33 +309,31 @@ extern struct dhcp6_list bcmcslist;
 extern struct dhcp6_list bcmcsnamelist;
 extern long long optrefreshtime;
 
-struct dhcp6_if *ifinit(char *);
-int ifreset(struct dhcp6_if *);
-int configure_interface(struct cf_namelist *);
-int configure_host(struct cf_namelist *);
-int configure_keys(struct cf_namelist *);
-int configure_authinfo(struct cf_namelist *);
-int configure_ia(struct cf_namelist *, iatype_t);
-int configure_global_option(void);
-void configure_cleanup(void);
-void configure_commit(void);
-int cfparse(const char *);
-struct dhcp6_if *find_ifconfbyname(char *);
-struct dhcp6_if *find_ifconfbyid(unsigned int);
-struct prefix_ifconf *find_prefixifconf(char *);
-struct host_conf *find_hostconf(struct duid *);
-struct authinfo *find_authinfo(struct authinfo *, char *);
-struct dhcp6_prefix *find_prefix6(struct dhcp6_list *,
-					      struct dhcp6_prefix *);
-struct ia_conf *find_iaconf(struct ia_conflist *, int, uint32_t);
-struct keyinfo *find_key(char *, size_t, uint32_t);
-int configure_pool(struct cf_namelist *);
-struct pool_conf *find_pool(const char *);
-int is_available_in_pool(struct pool_conf *, struct in6_addr *);
-int get_free_address_from_pool(struct pool_conf *,
-	struct in6_addr *);
-struct host_conf *create_dynamic_hostconf(struct duid *,
-	struct dhcp6_poolspec *);
-char *qstrdup(char *);
-
-#endif
+extern struct dhcp6_if *ifinit __P((char *));
+extern int ifreset __P((struct dhcp6_if *));
+extern int configure_interface __P((struct cf_namelist *));
+extern int configure_host __P((struct cf_namelist *));
+extern int configure_keys __P((struct cf_namelist *));
+extern int configure_authinfo __P((struct cf_namelist *));
+extern int configure_ia __P((struct cf_namelist *, iatype_t));
+extern int configure_global_option __P((void));
+extern void configure_cleanup __P((void));
+extern void configure_commit __P((void));
+extern int cfparse __P((char *));
+extern struct dhcp6_if *find_ifconfbyname __P((char *));
+extern struct dhcp6_if *find_ifconfbyid __P((unsigned int));
+extern struct prefix_ifconf *find_prefixifconf __P((char *));
+extern struct host_conf *find_hostconf __P((struct duid *));
+extern struct authinfo *find_authinfo __P((struct authinfo *, char *));
+extern struct dhcp6_prefix *find_prefix6 __P((struct dhcp6_list *,
+					      struct dhcp6_prefix *));
+extern struct ia_conf *find_iaconf __P((struct ia_conflist *, int, u_int32_t));
+extern struct keyinfo *find_key __P((char *, size_t, u_int32_t));
+extern int configure_pool __P((struct cf_namelist *));
+extern struct pool_conf *find_pool __P((const char *));
+extern int is_available_in_pool __P((struct pool_conf *, struct in6_addr *));
+extern int get_free_address_from_pool __P((struct pool_conf *,
+	struct in6_addr *));
+struct host_conf *create_dynamic_hostconf __P((struct duid *,
+	struct dhcp6_poolspec *));
+extern char *qstrdup __P((char *));

--- a/dhcp6.h
+++ b/dhcp6.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 1998 and 1999 WIDE Project.
  * All rights reserved.
- *
+ * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -14,7 +14,7 @@
  * 3. Neither the name of the project nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,9 +28,21 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _DHCP6_H_
-#define _DHCP6_H_
+#ifndef __DHCP6_H_DEFINED
+#define __DHCP6_H_DEFINED
 
+#ifdef __sun__
+#define	__P(x)	x
+typedef uint8_t u_int8_t;
+#ifndef	U_INT16_T_DEFINED
+#define	U_INT16_T_DEFINED
+typedef uint16_t u_int16_t;
+#endif
+#ifndef	U_INT32_T_DEFINED
+#define	U_INT32_T_DEFINED
+typedef uint32_t u_int32_t;
+#endif
+typedef uint64_t u_int64_t;
 #ifndef CMSG_SPACE
 #define	CMSG_SPACE(l) \
 	((unsigned int)_CMSG_HDR_ALIGN(sizeof (struct cmsghdr) + (l)))
@@ -38,6 +50,7 @@
 #ifndef CMSG_LEN
 #define	CMSG_LEN(l) \
 	((unsigned int)_CMSG_DATA_ALIGN(sizeof (struct cmsghdr)) + (l))
+#endif
 #endif
 
 /* Error Values */
@@ -95,6 +108,17 @@
 #define DHCP6_IRT_DEFAULT 86400	/* 1 day */
 #define DHCP6_IRT_MINIMUM 600
 
+/* XXX */
+TAILQ_HEAD(rawop_list, rawoption);
+struct rawoption {
+	TAILQ_ENTRY(rawoption) link;
+	
+	int opnum;
+	char *data;
+	int datalen;
+};
+
+
 /* DUID: DHCP unique Identifier */
 struct duid {
 	size_t duid_len;	/* length */
@@ -108,21 +132,21 @@ struct dhcp6_vbuf {		/* generic variable length buffer */
 
 /* option information */
 struct dhcp6_ia {		/* identity association */
-	uint32_t iaid;
-	uint32_t t1;
-	uint32_t t2;
+	u_int32_t iaid;
+	u_int32_t t1;
+	u_int32_t t2;
 };
 
 struct dhcp6_prefix {		/* IA_PA */
-	uint32_t pltime;
-	uint32_t vltime;
+	u_int32_t pltime;
+	u_int32_t vltime;
 	struct in6_addr addr;
 	int plen;
 };
 
 struct dhcp6_statefuladdr {	/* IA_NA */
-	uint32_t pltime;
-	uint32_t vltime;
+	u_int32_t pltime;
+	u_int32_t vltime;
 	struct in6_addr addr;
 };
 
@@ -141,7 +165,7 @@ struct dhcp6_listval {
 
 	union {
 		int uv_num;
-		uint16_t uv_num16;
+		u_int16_t uv_num16;
 		struct in6_addr uv_addr6;
 		struct dhcp6_prefix uv_prefix6;
 		struct dhcp6_statefuladdr uv_statefuladdr6;
@@ -184,6 +208,9 @@ struct dhcp6_optinfo {
 	struct dhcp6_list nispname_list; /* NIS+ domain list */
 	struct dhcp6_list bcmcs_list; /* BCMC server list */
 	struct dhcp6_list bcmcsname_list; /* BCMC domain list */
+	/* XXX */
+	struct rawop_list rawops;
+	
 
 	struct dhcp6_vbuf relay_msg; /* relay message */
 #define relaymsg_len relay_msg.dv_len
@@ -199,10 +226,10 @@ struct dhcp6_optinfo {
 	int authalgorithm;
 	int authrdm;
 	/* the followings are effective only when NOINFO is unset */
-	uint64_t authrd;
+	u_int64_t authrd;
 	union {
 		struct {
-			uint32_t keyid;
+			u_int32_t keyid;
 			struct dhcp6_vbuf realm;
 			int offset; /* offset to the HMAC field */
 		} aiu_delayed;
@@ -224,8 +251,8 @@ struct dhcp6_optinfo {
 /* DHCP6 base packet format */
 struct dhcp6 {
 	union {
-		uint8_t m;
-		uint32_t x;
+		u_int8_t m;
+		u_int32_t x;
 	} dh6_msgtypexid;
 	/* options follow */
 } __attribute__ ((__packed__));
@@ -235,8 +262,8 @@ struct dhcp6 {
 
 /* DHCPv6 relay messages */
 struct dhcp6_relay {
-	uint8_t dh6relay_msgtype;
-	uint8_t dh6relay_hcnt;
+	u_int8_t dh6relay_msgtype;
+	u_int8_t dh6relay_hcnt;
 	struct in6_addr dh6relay_linkaddr; /* XXX: badly aligned */
 	struct in6_addr dh6relay_peeraddr; /* ditto */
 	/* options follow */
@@ -300,24 +327,24 @@ struct dhcp6_relay {
 /* The followings are KAME specific. */
 
 struct dhcp6opt {
-	uint16_t dh6opt_type;
-	uint16_t dh6opt_len;
+	u_int16_t dh6opt_type;
+	u_int16_t dh6opt_len;
 	/* type-dependent data follows */
 } __attribute__ ((__packed__));
 
 /* DUID type 1 */
 struct dhcp6opt_duid_type1 {
-	uint16_t dh6_duid1_type;
-	uint16_t dh6_duid1_hwtype;
-	uint32_t dh6_duid1_time;
+	u_int16_t dh6_duid1_type;
+	u_int16_t dh6_duid1_hwtype;
+	u_int32_t dh6_duid1_time;
 	/* link-layer address follows */
 } __attribute__ ((__packed__));
 
 /* Status Code */
 struct dhcp6opt_stcode {
-	uint16_t dh6_stcode_type;
-	uint16_t dh6_stcode_len;
-	uint16_t dh6_stcode_code;
+	u_int16_t dh6_stcode_type;
+	u_int16_t dh6_stcode_len;
+	u_int16_t dh6_stcode_code;
 } __attribute__ ((__packed__));
 
 /*
@@ -326,41 +353,41 @@ struct dhcp6opt_stcode {
  * (IA_NA)
  */
 struct dhcp6opt_ia {
-	uint16_t dh6_ia_type;
-	uint16_t dh6_ia_len;
-	uint32_t dh6_ia_iaid;
-	uint32_t dh6_ia_t1;
-	uint32_t dh6_ia_t2;
+	u_int16_t dh6_ia_type;
+	u_int16_t dh6_ia_len;
+	u_int32_t dh6_ia_iaid;
+	u_int32_t dh6_ia_t1;
+	u_int32_t dh6_ia_t2;
 	/* sub options follow */
 } __attribute__ ((__packed__));
 
 /* IA Addr */
 struct dhcp6opt_ia_addr {
-	uint16_t dh6_ia_addr_type;
-	uint16_t dh6_ia_addr_len;
+	u_int16_t dh6_ia_addr_type;
+	u_int16_t dh6_ia_addr_len;
 	struct in6_addr dh6_ia_addr_addr;
-	uint32_t dh6_ia_addr_preferred_time;
-	uint32_t dh6_ia_addr_valid_time;
+	u_int32_t dh6_ia_addr_preferred_time;
+	u_int32_t dh6_ia_addr_valid_time;
 } __attribute__ ((__packed__));
 
 /* IA_PD Prefix */
 struct dhcp6opt_ia_pd_prefix {
-	uint16_t dh6_iapd_prefix_type;
-	uint16_t dh6_iapd_prefix_len;
-	uint32_t dh6_iapd_prefix_preferred_time;
-	uint32_t dh6_iapd_prefix_valid_time;
-	uint8_t dh6_iapd_prefix_prefix_len;
+	u_int16_t dh6_iapd_prefix_type;
+	u_int16_t dh6_iapd_prefix_len;
+	u_int32_t dh6_iapd_prefix_preferred_time;
+	u_int32_t dh6_iapd_prefix_valid_time;
+	u_int8_t dh6_iapd_prefix_prefix_len;
 	struct in6_addr dh6_iapd_prefix_prefix_addr;
 } __attribute__ ((__packed__));
 
 /* Authentication */
 struct dhcp6opt_auth {
-	uint16_t dh6_auth_type;
-	uint16_t dh6_auth_len;
-	uint8_t dh6_auth_proto;
-	uint8_t dh6_auth_alg;
-	uint8_t dh6_auth_rdm;
-	uint8_t dh6_auth_rdinfo[8];
+	u_int16_t dh6_auth_type;
+	u_int16_t dh6_auth_len;
+	u_int8_t dh6_auth_proto;
+	u_int8_t dh6_auth_alg;
+	u_int8_t dh6_auth_rdm;
+	u_int8_t dh6_auth_rdinfo[8];
 	/* authentication information follows */
 } __attribute__ ((__packed__));
 
@@ -369,4 +396,4 @@ enum { DHCP6_AUTHPROTO_UNDEF = -1, DHCP6_AUTHPROTO_DELAYED = 2,
 enum { DHCP6_AUTHALG_UNDEF = -1, DHCP6_AUTHALG_HMACMD5 = 1 };
 enum { DHCP6_AUTHRDM_UNDEF = -1, DHCP6_AUTHRDM_MONOCOUNTER = 0 };
 
-#endif
+#endif /*__DHCP6_H_DEFINED*/


### PR DESCRIPTION
In its current form dhcp6c is limited by the number of OPTIONS that can be sent. This means that for certain ISP's it will not work.

The changes here add the ability to add as many options as needed using the RAW parameter.

For example, these are taken from a working system.

User class "+FSVDSL_livebox.Internet.softathome.Livebox3";

send raw-option 15 00:2b:46:53:56:44:53:4c:5f:6c:69:76:65:62:6f:78:2e:49:6e:74:65:72:6e:65:74:2e:73:6f:66:74:61:74:68:6f:6d:65:2e:6c:69:76:65:62:6f:78:33;

Vendor class "sagem"

send raw-option 16 00:00:04:0e:00:05:73:61:67:65:6d;

Authentication

send raw-option 11 00:00:00:00:00:00:00:00:00:00:00:61:71:81:2d:66:73:71:71:36:41:78;

It can be seen that the option number is the first number after the "send raw-option, entered as a decimal number.

For example, in the User Class, rfc3315 states that for user class, all that is required is the option length - first byte, then the string itself. As the length will be calculated and entered automatically this is set to 0, or in hex 00. The string is then entered, converted to hex bytes as shown below.

+FSVDSL_livebox.Internet.softathome.Livebox3

becomes

00:2b:46:53:56:44:53:4c:5f:6c:69:76:65:62:6f:78:2e:49:6e:74:65:72:6e:65:74:2e:73:6f:66:74:61:74:68:6f:6d:65:2e:6c:69:76:65:62:6f:78:33

Care obviously needs to be taken when creating these parameters and it is for the advanced only, but it does allow any option(s) to be added, and it works!